### PR TITLE
Whisper - Implemented Create/Edit/IndexPage for menuitem, updated App.jsx and navBar, passed coverage test for the new pages

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -74,7 +74,11 @@ function App() {
       )}
       {hasRole(currentUser, "ROLE_USER") && (
         <>
-          <Route exact path="/ucsbdiningcommonmenuitems" element={<UCSBDiningCommonMenuItemsIndexPage />} />
+          <Route
+            exact
+            path="/ucsbdiningcommonmenuitems"
+            element={<UCSBDiningCommonMenuItemsIndexPage />}
+          />
         </>
       )}
       {hasRole(currentUser, "ROLE_ADMIN") && (

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -11,6 +11,10 @@ import RestaurantIndexPage from "main/pages/Restaurants/RestaurantIndexPage";
 import RestaurantCreatePage from "main/pages/Restaurants/RestaurantCreatePage";
 import RestaurantEditPage from "main/pages/Restaurants/RestaurantEditPage";
 
+import UCSBDiningCommonMenuItemsIndexPage from "main/pages/UCSBDiningCommonMenuItems/UCSBDiningCommonMenuItemsIndexPage";
+import UCSBDiningCommonMenuItemsCreatePage from "main/pages/UCSBDiningCommonMenuItems/UCSBDiningCommonMenuItemsCreatePage";
+import UCSBDiningCommonMenuItemsEditPage from "main/pages/UCSBDiningCommonMenuItems/UCSBDiningCommonMenuItemsEditPage";
+
 import PlaceholderIndexPage from "main/pages/Placeholder/PlaceholderIndexPage";
 import PlaceholderCreatePage from "main/pages/Placeholder/PlaceholderCreatePage";
 import PlaceholderEditPage from "main/pages/Placeholder/PlaceholderEditPage";
@@ -65,6 +69,25 @@ function App() {
             exact
             path="/restaurants/create"
             element={<RestaurantCreatePage />}
+          />
+        </>
+      )}
+      {hasRole(currentUser, "ROLE_USER") && (
+        <>
+          <Route exact path="/ucsbdiningcommonmenuitems" element={<UCSBDiningCommonMenuItemsIndexPage />} />
+        </>
+      )}
+      {hasRole(currentUser, "ROLE_ADMIN") && (
+        <>
+          <Route
+            exact
+            path="/ucsbdiningcommonmenuitems/edit/:id"
+            element={<UCSBDiningCommonMenuItemsEditPage />}
+          />
+          <Route
+            exact
+            path="/ucsbdiningcommonmenuitems/create"
+            element={<UCSBDiningCommonMenuItemsCreatePage />}
           />
         </>
       )}

--- a/frontend/src/main/components/Nav/AppNavbar.jsx
+++ b/frontend/src/main/components/Nav/AppNavbar.jsx
@@ -68,6 +68,9 @@ export default function AppNavbar({
                   <Nav.Link as={Link} to="/ucsbdates">
                     UCSB Dates
                   </Nav.Link>
+                  <Nav.Link as={Link} to="/ucsbdiningcommonmenuitems">
+                    UCSBDiningCommonMenuItems
+                  </Nav.Link>
                   <Nav.Link as={Link} to="/placeholder">
                     Placeholder
                   </Nav.Link>

--- a/frontend/src/main/components/UCSBDiningCommonMenuItems/UCSBDiningCommonMenuItemsTable.jsx
+++ b/frontend/src/main/components/UCSBDiningCommonMenuItems/UCSBDiningCommonMenuItemsTable.jsx
@@ -24,7 +24,7 @@ export default function UCSBDiningCommonMenuItemsTable({
   const deleteMutation = useBackendMutation(
     cellToAxiosParamsDelete,
     { onSuccess: onDeleteSuccess },
-    ["/api/ucsbdiningcommonmenuitems/all"],
+    ["/api/ucsbdiningcommonsmenuitems/all"],
   );
   // Stryker restore all
 

--- a/frontend/src/main/pages/UCSBDiningCommonMenuItems/UCSBDiningCommonMenuItemsCreatePage.jsx
+++ b/frontend/src/main/pages/UCSBDiningCommonMenuItems/UCSBDiningCommonMenuItemsCreatePage.jsx
@@ -4,7 +4,9 @@ import { Navigate } from "react-router";
 import { useBackendMutation } from "main/utils/useBackend";
 import { toast } from "react-toastify";
 
-export default function UCSBDiningCommonMenuItemsCreatePage({ storybook = false }) {
+export default function UCSBDiningCommonMenuItemsCreatePage({
+  storybook = false,
+}) {
   const objectToAxiosParams = (ucsbDiningCommonMenuItem) => ({
     url: "/api/ucsbdiningcommonmenuitems/post",
     method: "POST",

--- a/frontend/src/main/pages/UCSBDiningCommonMenuItems/UCSBDiningCommonMenuItemsCreatePage.jsx
+++ b/frontend/src/main/pages/UCSBDiningCommonMenuItems/UCSBDiningCommonMenuItemsCreatePage.jsx
@@ -1,0 +1,50 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import UCSBDiningCommonMenuItemForm from "main/components/UCSBDiningCommonMenuItems/UCSBDiningCommonMenuItemForm";
+import { Navigate } from "react-router";
+import { useBackendMutation } from "main/utils/useBackend";
+import { toast } from "react-toastify";
+
+export default function UCSBDiningCommonMenuItemsCreatePage({ storybook = false }) {
+  const objectToAxiosParams = (ucsbDiningCommonMenuItem) => ({
+    url: "/api/ucsbdiningcommonmenuitems/post",
+    method: "POST",
+    params: {
+      diningCommonsCode: ucsbDiningCommonMenuItem.diningCommonsCode,
+      name: ucsbDiningCommonMenuItem.name,
+      station: ucsbDiningCommonMenuItem.station,
+    },
+  });
+
+  const onSuccess = (ucsbDiningCommonMenuItem) => {
+    toast(
+      `New ucsbDiningCommonMenuItem Created - id: ${ucsbDiningCommonMenuItem.id} diningCommonsCode: ${ucsbDiningCommonMenuItem.diningCommonsCode} name: ${ucsbDiningCommonMenuItem.name} station: ${ucsbDiningCommonMenuItem.station}`,
+    );
+  };
+
+  const mutation = useBackendMutation(
+    objectToAxiosParams,
+    { onSuccess },
+    // Stryker disable next-line all : hard to set up test for caching
+    ["/api/ucsbdiningcommonmenuitems/all"],
+  );
+
+  const { isSuccess } = mutation;
+
+  const onSubmit = async (data) => {
+    mutation.mutate(data);
+  };
+
+  if (isSuccess && !storybook) {
+    return <Navigate to="/ucsbdiningcommonmenuitems" />;
+  }
+
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Create New UCSBDiningCommonMenuItem</h1>
+
+        <UCSBDiningCommonMenuItemForm submitAction={onSubmit} />
+      </div>
+    </BasicLayout>
+  );
+}

--- a/frontend/src/main/pages/UCSBDiningCommonMenuItems/UCSBDiningCommonMenuItemsCreatePage.jsx
+++ b/frontend/src/main/pages/UCSBDiningCommonMenuItems/UCSBDiningCommonMenuItemsCreatePage.jsx
@@ -8,7 +8,7 @@ export default function UCSBDiningCommonMenuItemsCreatePage({
   storybook = false,
 }) {
   const objectToAxiosParams = (ucsbDiningCommonMenuItem) => ({
-    url: "/api/ucsbdiningcommonmenuitems/post",
+    url: "/api/ucsbdiningcommonsmenuitems/post",
     method: "POST",
     params: {
       diningCommonsCode: ucsbDiningCommonMenuItem.diningCommonsCode,
@@ -27,7 +27,7 @@ export default function UCSBDiningCommonMenuItemsCreatePage({
     objectToAxiosParams,
     { onSuccess },
     // Stryker disable next-line all : hard to set up test for caching
-    ["/api/ucsbdiningcommonmenuitems/all"],
+    ["/api/ucsbdiningcommonsmenuitems/all"],
   );
 
   const { isSuccess } = mutation;

--- a/frontend/src/main/pages/UCSBDiningCommonMenuItems/UCSBDiningCommonMenuItemsEditPage.jsx
+++ b/frontend/src/main/pages/UCSBDiningCommonMenuItems/UCSBDiningCommonMenuItemsEditPage.jsx
@@ -5,7 +5,9 @@ import { Navigate } from "react-router";
 import { useBackend, useBackendMutation } from "main/utils/useBackend";
 import { toast } from "react-toastify";
 
-export default function UCSBDiningCommonMenuItemsEditPage({ storybook = false }) {
+export default function UCSBDiningCommonMenuItemsEditPage({
+  storybook = false,
+}) {
   let { id } = useParams();
 
   const {
@@ -39,7 +41,9 @@ export default function UCSBDiningCommonMenuItemsEditPage({ storybook = false })
   });
 
   const onSuccess = (ucsbDiningCommonMenuItem) => {
-    toast(`UCSBDiningCommonMenuItem Updated - id: ${ucsbDiningCommonMenuItem.id} diningCommonsCode: ${ucsbDiningCommonMenuItem.diningCommonsCode} name: ${ucsbDiningCommonMenuItem.name} station: ${ucsbDiningCommonMenuItem.station}`);
+    toast(
+      `UCSBDiningCommonMenuItem Updated - id: ${ucsbDiningCommonMenuItem.id} diningCommonsCode: ${ucsbDiningCommonMenuItem.diningCommonsCode} name: ${ucsbDiningCommonMenuItem.name} station: ${ucsbDiningCommonMenuItem.station}`,
+    );
   };
 
   const mutation = useBackendMutation(

--- a/frontend/src/main/pages/UCSBDiningCommonMenuItems/UCSBDiningCommonMenuItemsEditPage.jsx
+++ b/frontend/src/main/pages/UCSBDiningCommonMenuItems/UCSBDiningCommonMenuItemsEditPage.jsx
@@ -16,11 +16,11 @@ export default function UCSBDiningCommonMenuItemsEditPage({
     _status,
   } = useBackend(
     // Stryker disable next-line all : don't test internal caching of React Query
-    [`/api/ucsbdiningcommonmenuitems?id=${id}`],
+    [`/api/ucsbdiningcommonsmenuitems?id=${id}`],
     {
       // Stryker disable next-line all : GET is the default, so changing this to "" doesn't introduce a bug
       method: "GET",
-      url: `/api/ucsbdiningcommonmenuitems`,
+      url: `/api/ucsbdiningcommonsmenuitems`,
       params: {
         id,
       },
@@ -28,7 +28,7 @@ export default function UCSBDiningCommonMenuItemsEditPage({
   );
 
   const objectToAxiosPutParams = (ucsbDiningCommonMenuItem) => ({
-    url: "/api/ucsbdiningcommonmenuitems",
+    url: "/api/ucsbdiningcommonsmenuitems",
     method: "PUT",
     params: {
       id: ucsbDiningCommonMenuItem.id,
@@ -50,7 +50,7 @@ export default function UCSBDiningCommonMenuItemsEditPage({
     objectToAxiosPutParams,
     { onSuccess },
     // Stryker disable next-line all : hard to set up test for caching
-    [`/api/ucsbdiningcommonmenuitems?id=${id}`],
+    [`/api/ucsbdiningcommonsmenuitems?id=${id}`],
   );
 
   const { isSuccess } = mutation;

--- a/frontend/src/main/pages/UCSBDiningCommonMenuItems/UCSBDiningCommonMenuItemsEditPage.jsx
+++ b/frontend/src/main/pages/UCSBDiningCommonMenuItems/UCSBDiningCommonMenuItemsEditPage.jsx
@@ -1,0 +1,76 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import { useParams } from "react-router";
+import UCSBDiningCommonMenuItemForm from "main/components/UCSBDiningCommonMenuItems/UCSBDiningCommonMenuItemForm";
+import { Navigate } from "react-router";
+import { useBackend, useBackendMutation } from "main/utils/useBackend";
+import { toast } from "react-toastify";
+
+export default function UCSBDiningCommonMenuItemsEditPage({ storybook = false }) {
+  let { id } = useParams();
+
+  const {
+    data: ucsbDiningCommonMenuItem,
+    _error,
+    _status,
+  } = useBackend(
+    // Stryker disable next-line all : don't test internal caching of React Query
+    [`/api/ucsbdiningcommonmenuitems?id=${id}`],
+    {
+      // Stryker disable next-line all : GET is the default, so changing this to "" doesn't introduce a bug
+      method: "GET",
+      url: `/api/ucsbdiningcommonmenuitems`,
+      params: {
+        id,
+      },
+    },
+  );
+
+  const objectToAxiosPutParams = (ucsbDiningCommonMenuItem) => ({
+    url: "/api/ucsbdiningcommonmenuitems",
+    method: "PUT",
+    params: {
+      id: ucsbDiningCommonMenuItem.id,
+    },
+    data: {
+      diningCommonsCode: ucsbDiningCommonMenuItem.diningCommonsCode,
+      name: ucsbDiningCommonMenuItem.name,
+      station: ucsbDiningCommonMenuItem.station,
+    },
+  });
+
+  const onSuccess = (ucsbDiningCommonMenuItem) => {
+    toast(`UCSBDiningCommonMenuItem Updated - id: ${ucsbDiningCommonMenuItem.id} diningCommonsCode: ${ucsbDiningCommonMenuItem.diningCommonsCode} name: ${ucsbDiningCommonMenuItem.name} station: ${ucsbDiningCommonMenuItem.station}`);
+  };
+
+  const mutation = useBackendMutation(
+    objectToAxiosPutParams,
+    { onSuccess },
+    // Stryker disable next-line all : hard to set up test for caching
+    [`/api/ucsbdiningcommonmenuitems?id=${id}`],
+  );
+
+  const { isSuccess } = mutation;
+
+  const onSubmit = async (data) => {
+    mutation.mutate(data);
+  };
+
+  if (isSuccess && !storybook) {
+    return <Navigate to="/ucsbdiningcommonmenuitems" />;
+  }
+
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Edit UCSBDiningCommonMenuItem</h1>
+        {ucsbDiningCommonMenuItem && (
+          <UCSBDiningCommonMenuItemForm
+            initialContents={ucsbDiningCommonMenuItem}
+            submitAction={onSubmit}
+            buttonLabel="Update"
+          />
+        )}
+      </div>
+    </BasicLayout>
+  );
+}

--- a/frontend/src/main/pages/UCSBDiningCommonMenuItems/UCSBDiningCommonMenuItemsIndexPage.jsx
+++ b/frontend/src/main/pages/UCSBDiningCommonMenuItems/UCSBDiningCommonMenuItemsIndexPage.jsx
@@ -1,0 +1,49 @@
+import React from "react";
+import { useBackend } from "main/utils/useBackend";
+
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import UCSBDiningCommonMenuItemsTable from "main/components/UCSBDiningCommonMenuItems/UCSBDiningCommonMenuItemsTable";
+import { Button } from "react-bootstrap";
+import { useCurrentUser, hasRole } from "main/utils/useCurrentUser";
+
+export default function UCSBDiningCommonMenuItemsIndexPage() {
+  const currentUser = useCurrentUser();
+
+  const createButton = () => {
+    if (hasRole(currentUser, "ROLE_ADMIN")) {
+      return (
+        <Button
+          variant="primary"
+          href="/ucsbdiningcommonmenuitems/create"
+          style={{ float: "right" }}
+        >
+          Create UCSBDiningCommonMenuItem
+        </Button>
+      );
+    }
+  };
+
+  const {
+    data: menuItems,
+    error: _error,
+    status: _status,
+  } = useBackend(
+    // Stryker disable next-line all : don't test internal caching of React Query
+    ["/api/ucsbdiningcommonmenuitems/all"],
+    { method: "GET", url: "/api/ucsbdiningcommonmenuitems/all" },
+    [],
+  );
+
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        {createButton()}
+        <h1>UCSBDiningCommonMenuItems</h1>
+        <UCSBDiningCommonMenuItemsTable
+          diningCommonMenuItems={menuItems}
+          currentUser={currentUser}
+        />
+      </div>
+    </BasicLayout>
+  );
+}

--- a/frontend/src/main/pages/UCSBDiningCommonMenuItems/UCSBDiningCommonMenuItemsIndexPage.jsx
+++ b/frontend/src/main/pages/UCSBDiningCommonMenuItems/UCSBDiningCommonMenuItemsIndexPage.jsx
@@ -29,8 +29,8 @@ export default function UCSBDiningCommonMenuItemsIndexPage() {
     status: _status,
   } = useBackend(
     // Stryker disable next-line all : don't test internal caching of React Query
-    ["/api/ucsbdiningcommonmenuitems/all"],
-    { method: "GET", url: "/api/ucsbdiningcommonmenuitems/all" },
+    ["/api/ucsbdiningcommonsmenuitems/all"],
+    { method: "GET", url: "/api/ucsbdiningcommonsmenuitems/all" },
     [],
   );
 

--- a/frontend/src/main/utils/UCSBDiningCommonMenuItemUtils.js
+++ b/frontend/src/main/utils/UCSBDiningCommonMenuItemUtils.js
@@ -7,7 +7,7 @@ export function onDeleteSuccess(message) {
 
 export function cellToAxiosParamsDelete(cell) {
   return {
-    url: "/api/ucsbdiningcommonmenuitems",
+    url: "/api/ucsbdiningcommonsmenuitems",
     method: "DELETE",
     params: {
       id: cell.row.original.id,

--- a/frontend/src/stories/components/UCSBDiningCommonMenuItems/UCSBDiningCommonMenuItemsTable.stories.jsx
+++ b/frontend/src/stories/components/UCSBDiningCommonMenuItems/UCSBDiningCommonMenuItemsTable.stories.jsx
@@ -34,7 +34,7 @@ ThreeItemsAdminUser.args = {
 
 ThreeItemsAdminUser.parameters = {
   msw: [
-    http.delete("/api/ucsbdiningcommonmenuitems", () => {
+    http.delete("/api/ucsbdiningcommonsmenuitems", () => {
       return HttpResponse.json(
         { message: "UCSBDiningCommonMenuItem deleted successfully" },
         { status: 200 },

--- a/frontend/src/stories/pages/UCSBDiningCommonMenuItems/UCSBDiningCommonMenuItemsCreatePage.stories.jsx
+++ b/frontend/src/stories/pages/UCSBDiningCommonMenuItems/UCSBDiningCommonMenuItemsCreatePage.stories.jsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { http, HttpResponse } from "msw";
+
+import UCSBDiningCommonMenuItemsCreatePage from "main/pages/UCSBDiningCommonMenuItems/UCSBDiningCommonMenuItemsCreatePage";
+
+export default {
+  title: "pages/UCSBDiningCommonMenuItems/UCSBDiningCommonMenuItemsCreatePage",
+  component: UCSBDiningCommonMenuItemsCreatePage,
+};
+
+const Template = () => <UCSBDiningCommonMenuItemsCreatePage storybook={true} />;
+
+export const Default = Template.bind({});
+Default.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.userOnly, {
+        status: 200,
+      });
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither, {
+        status: 200,
+      });
+    }),
+    http.post("/api/ucsbdiningcommonmenuitems/post", () => {
+      return HttpResponse.json({}, { status: 200 });
+    }),
+  ],
+};

--- a/frontend/src/stories/pages/UCSBDiningCommonMenuItems/UCSBDiningCommonMenuItemsCreatePage.stories.jsx
+++ b/frontend/src/stories/pages/UCSBDiningCommonMenuItems/UCSBDiningCommonMenuItemsCreatePage.stories.jsx
@@ -25,7 +25,7 @@ Default.parameters = {
         status: 200,
       });
     }),
-    http.post("/api/ucsbdiningcommonmenuitems/post", () => {
+    http.post("/api/ucsbdiningcommonsmenuitems/post", () => {
       return HttpResponse.json({}, { status: 200 });
     }),
   ],

--- a/frontend/src/stories/pages/UCSBDiningCommonMenuItems/UCSBDiningCommonMenuItemsEditPage.stories.jsx
+++ b/frontend/src/stories/pages/UCSBDiningCommonMenuItems/UCSBDiningCommonMenuItemsEditPage.stories.jsx
@@ -1,0 +1,41 @@
+import React from "react";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { ucsbDiningCommonMenuItemsFixtures } from "fixtures/ucsbDiningCommonMenuItemsFixtures";
+import { http, HttpResponse } from "msw";
+
+import UCSBDiningCommonMenuItemsEditPage from "main/pages/UCSBDiningCommonMenuItems/UCSBDiningCommonMenuItemsEditPage";
+
+export default {
+  title: "pages/UCSBDiningCommonMenuItems/UCSBDiningCommonMenuItemsEditPage",
+  component: UCSBDiningCommonMenuItemsEditPage,
+};
+
+const Template = () => <UCSBDiningCommonMenuItemsEditPage storybook={true} />;
+
+export const Default = Template.bind({});
+Default.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.userOnly, {
+        status: 200,
+      });
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither, {
+        status: 200,
+      });
+    }),
+    http.get("/api/ucsbdiningcommonmenuitems", () => {
+      return HttpResponse.json(
+        ucsbDiningCommonMenuItemsFixtures.threeMenuItems[0],
+        {
+          status: 200,
+        },
+      );
+    }),
+    http.put("/api/ucsbdiningcommonmenuitems", () => {
+      return HttpResponse.json({}, { status: 200 });
+    }),
+  ],
+};

--- a/frontend/src/stories/pages/UCSBDiningCommonMenuItems/UCSBDiningCommonMenuItemsEditPage.stories.jsx
+++ b/frontend/src/stories/pages/UCSBDiningCommonMenuItems/UCSBDiningCommonMenuItemsEditPage.stories.jsx
@@ -26,7 +26,7 @@ Default.parameters = {
         status: 200,
       });
     }),
-    http.get("/api/ucsbdiningcommonmenuitems", () => {
+    http.get("/api/ucsbdiningcommonsmenuitems", () => {
       return HttpResponse.json(
         ucsbDiningCommonMenuItemsFixtures.threeMenuItems[0],
         {
@@ -34,7 +34,7 @@ Default.parameters = {
         },
       );
     }),
-    http.put("/api/ucsbdiningcommonmenuitems", () => {
+    http.put("/api/ucsbdiningcommonsmenuitems", () => {
       return HttpResponse.json({}, { status: 200 });
     }),
   ],

--- a/frontend/src/stories/pages/UCSBDiningCommonMenuItems/UCSBDiningCommonMenuItemsIndexPage.stories.jsx
+++ b/frontend/src/stories/pages/UCSBDiningCommonMenuItems/UCSBDiningCommonMenuItemsIndexPage.stories.jsx
@@ -26,7 +26,7 @@ Empty.parameters = {
         status: 200,
       });
     }),
-    http.get("/api/ucsbdiningcommonmenuitems/all", () => {
+    http.get("/api/ucsbdiningcommonsmenuitems/all", () => {
       return HttpResponse.json([], { status: 200 });
     }),
   ],
@@ -42,7 +42,7 @@ ThreeItemsOrdinaryUser.parameters = {
     http.get("/api/systemInfo", () => {
       return HttpResponse.json(systemInfoFixtures.showingNeither);
     }),
-    http.get("/api/ucsbdiningcommonmenuitems/all", () => {
+    http.get("/api/ucsbdiningcommonsmenuitems/all", () => {
       return HttpResponse.json(
         ucsbDiningCommonMenuItemsFixtures.threeMenuItems,
       );
@@ -60,12 +60,12 @@ ThreeItemsAdminUser.parameters = {
     http.get("/api/systemInfo", () => {
       return HttpResponse.json(systemInfoFixtures.showingNeither);
     }),
-    http.get("/api/ucsbdiningcommonmenuitems/all", () => {
+    http.get("/api/ucsbdiningcommonsmenuitems/all", () => {
       return HttpResponse.json(
         ucsbDiningCommonMenuItemsFixtures.threeMenuItems,
       );
     }),
-    http.delete("/api/ucsbdiningcommonmenuitems", () => {
+    http.delete("/api/ucsbdiningcommonsmenuitems", () => {
       return HttpResponse.json({}, { status: 200 });
     }),
   ],

--- a/frontend/src/stories/pages/UCSBDiningCommonMenuItems/UCSBDiningCommonMenuItemsIndexPage.stories.jsx
+++ b/frontend/src/stories/pages/UCSBDiningCommonMenuItems/UCSBDiningCommonMenuItemsIndexPage.stories.jsx
@@ -1,0 +1,72 @@
+import React from "react";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { ucsbDiningCommonMenuItemsFixtures } from "fixtures/ucsbDiningCommonMenuItemsFixtures";
+import { http, HttpResponse } from "msw";
+
+import UCSBDiningCommonMenuItemsIndexPage from "main/pages/UCSBDiningCommonMenuItems/UCSBDiningCommonMenuItemsIndexPage";
+
+export default {
+  title: "pages/UCSBDiningCommonMenuItems/UCSBDiningCommonMenuItemsIndexPage",
+  component: UCSBDiningCommonMenuItemsIndexPage,
+};
+
+const Template = () => <UCSBDiningCommonMenuItemsIndexPage storybook={true} />;
+
+export const Empty = Template.bind({});
+Empty.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.userOnly, {
+        status: 200,
+      });
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither, {
+        status: 200,
+      });
+    }),
+    http.get("/api/ucsbdiningcommonmenuitems/all", () => {
+      return HttpResponse.json([], { status: 200 });
+    }),
+  ],
+};
+
+export const ThreeItemsOrdinaryUser = Template.bind({});
+
+ThreeItemsOrdinaryUser.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.userOnly);
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither);
+    }),
+    http.get("/api/ucsbdiningcommonmenuitems/all", () => {
+      return HttpResponse.json(
+        ucsbDiningCommonMenuItemsFixtures.threeMenuItems,
+      );
+    }),
+  ],
+};
+
+export const ThreeItemsAdminUser = Template.bind({});
+
+ThreeItemsAdminUser.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.adminUser);
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither);
+    }),
+    http.get("/api/ucsbdiningcommonmenuitems/all", () => {
+      return HttpResponse.json(
+        ucsbDiningCommonMenuItemsFixtures.threeMenuItems,
+      );
+    }),
+    http.delete("/api/ucsbdiningcommonmenuitems", () => {
+      return HttpResponse.json({}, { status: 200 });
+    }),
+  ],
+};

--- a/frontend/src/tests/pages/UCSBDiningCommonMenuItems/UCSBDiningCommonMenuItemsCreatePage.test.jsx
+++ b/frontend/src/tests/pages/UCSBDiningCommonMenuItems/UCSBDiningCommonMenuItemsCreatePage.test.jsx
@@ -1,0 +1,114 @@
+import { render, waitFor, fireEvent, screen } from "@testing-library/react";
+import UCSBDiningCommonMenuItemsCreatePage from "main/pages/UCSBDiningCommonMenuItems/UCSBDiningCommonMenuItemsCreatePage";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+const mockToast = vi.fn();
+vi.mock("react-toastify", async (importOriginal) => {
+  const originalModule = await importOriginal();
+  return {
+    ...originalModule,
+    toast: vi.fn((x) => mockToast(x)),
+  };
+});
+
+const mockNavigate = vi.fn();
+vi.mock("react-router", async (importOriginal) => {
+  const originalModule = await importOriginal();
+  return {
+    ...originalModule,
+    Navigate: vi.fn((x) => {
+      mockNavigate(x);
+      return null;
+    }),
+  };
+});
+
+describe("UCSBDiningCommonMenuItemsCreatePage tests", () => {
+  const axiosMock = new AxiosMockAdapter(axios);
+
+  beforeEach(() => {
+    axiosMock.reset();
+    axiosMock.resetHistory();
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.userOnly);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+  });
+
+  test("renders without crashing", async () => {
+    const queryClient = new QueryClient();
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <UCSBDiningCommonMenuItemsCreatePage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("UCSBDiningCommonMenuItemForm-diningCommonsCode"),
+      ).toBeInTheDocument();
+    });
+  });
+
+  test("when you fill in the form and hit submit, it makes a request to the backend", async () => {
+    const queryClient = new QueryClient();
+    const ucsbDiningCommonMenuItem = {
+      id: 17,
+      diningCommonsCode: "dining commons code 1",
+      name: "name 1",
+      station: "station 1",
+    };
+
+    axiosMock.onPost("/api/ucsbdiningcommonmenuitems/post").reply(202, ucsbDiningCommonMenuItem);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <UCSBDiningCommonMenuItemsCreatePage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("UCSBDiningCommonMenuItemForm-diningCommonsCode"),
+      ).toBeInTheDocument();
+    });
+
+    const diningCommonsCodeField = screen.getByTestId("UCSBDiningCommonMenuItemForm-diningCommonsCode");
+    const nameField = screen.getByTestId("UCSBDiningCommonMenuItemForm-name");
+    const stationField = screen.getByTestId("UCSBDiningCommonMenuItemForm-station");
+    const submitButton = screen.getByTestId("UCSBDiningCommonMenuItemForm-submit");
+
+    fireEvent.change(diningCommonsCodeField, { target: { value: "dining commons code 1" } });
+    fireEvent.change(nameField, { target: { value: "name 1" } });
+    fireEvent.change(stationField, { target: { value: "station 1" } });
+
+    expect(submitButton).toBeInTheDocument();
+
+    fireEvent.click(submitButton);
+
+    await waitFor(() => expect(axiosMock.history.post.length).toBe(1));
+
+    expect(axiosMock.history.post[0].params).toEqual({
+      diningCommonsCode: "dining commons code 1",
+      name: "name 1",
+      station: "station 1",
+    });
+
+    expect(mockToast).toBeCalledWith(
+      "New ucsbDiningCommonMenuItem Created - id: 17 diningCommonsCode: dining commons code 1 name: name 1 station: station 1",
+    );
+    expect(mockNavigate).toBeCalledWith({ to: "/ucsbdiningcommonmenuitems" });
+  });
+});

--- a/frontend/src/tests/pages/UCSBDiningCommonMenuItems/UCSBDiningCommonMenuItemsCreatePage.test.jsx
+++ b/frontend/src/tests/pages/UCSBDiningCommonMenuItems/UCSBDiningCommonMenuItemsCreatePage.test.jsx
@@ -70,7 +70,7 @@ describe("UCSBDiningCommonMenuItemsCreatePage tests", () => {
     };
 
     axiosMock
-      .onPost("/api/ucsbdiningcommonmenuitems/post")
+      .onPost("/api/ucsbdiningcommonsmenuitems/post")
       .reply(202, ucsbDiningCommonMenuItem);
 
     render(

--- a/frontend/src/tests/pages/UCSBDiningCommonMenuItems/UCSBDiningCommonMenuItemsCreatePage.test.jsx
+++ b/frontend/src/tests/pages/UCSBDiningCommonMenuItems/UCSBDiningCommonMenuItemsCreatePage.test.jsx
@@ -69,7 +69,9 @@ describe("UCSBDiningCommonMenuItemsCreatePage tests", () => {
       station: "station 1",
     };
 
-    axiosMock.onPost("/api/ucsbdiningcommonmenuitems/post").reply(202, ucsbDiningCommonMenuItem);
+    axiosMock
+      .onPost("/api/ucsbdiningcommonmenuitems/post")
+      .reply(202, ucsbDiningCommonMenuItem);
 
     render(
       <QueryClientProvider client={queryClient}>
@@ -85,12 +87,20 @@ describe("UCSBDiningCommonMenuItemsCreatePage tests", () => {
       ).toBeInTheDocument();
     });
 
-    const diningCommonsCodeField = screen.getByTestId("UCSBDiningCommonMenuItemForm-diningCommonsCode");
+    const diningCommonsCodeField = screen.getByTestId(
+      "UCSBDiningCommonMenuItemForm-diningCommonsCode",
+    );
     const nameField = screen.getByTestId("UCSBDiningCommonMenuItemForm-name");
-    const stationField = screen.getByTestId("UCSBDiningCommonMenuItemForm-station");
-    const submitButton = screen.getByTestId("UCSBDiningCommonMenuItemForm-submit");
+    const stationField = screen.getByTestId(
+      "UCSBDiningCommonMenuItemForm-station",
+    );
+    const submitButton = screen.getByTestId(
+      "UCSBDiningCommonMenuItemForm-submit",
+    );
 
-    fireEvent.change(diningCommonsCodeField, { target: { value: "dining commons code 1" } });
+    fireEvent.change(diningCommonsCodeField, {
+      target: { value: "dining commons code 1" },
+    });
     fireEvent.change(nameField, { target: { value: "name 1" } });
     fireEvent.change(stationField, { target: { value: "station 1" } });
 

--- a/frontend/src/tests/pages/UCSBDiningCommonMenuItems/UCSBDiningCommonMenuItemsEditPage.test.jsx
+++ b/frontend/src/tests/pages/UCSBDiningCommonMenuItems/UCSBDiningCommonMenuItemsEditPage.test.jsx
@@ -47,7 +47,7 @@ describe("UCSBDiningCommonMenuItemsEditPage tests", () => {
         .onGet("/api/systemInfo")
         .reply(200, systemInfoFixtures.showingNeither);
       axiosMock
-        .onGet("/api/ucsbdiningcommonmenuitems", { params: { id: 17 } })
+        .onGet("/api/ucsbdiningcommonsmenuitems", { params: { id: 17 } })
         .timeout();
     });
 
@@ -91,14 +91,14 @@ describe("UCSBDiningCommonMenuItemsEditPage tests", () => {
         .onGet("/api/systemInfo")
         .reply(200, systemInfoFixtures.showingNeither);
       axiosMock
-        .onGet("/api/ucsbdiningcommonmenuitems", { params: { id: 17 } })
+        .onGet("/api/ucsbdiningcommonsmenuitems", { params: { id: 17 } })
         .reply(200, {
           id: 17,
           diningCommonsCode: "dining commons code 1",
           name: "name 1",
           station: "station 1",
         });
-      axiosMock.onPut("/api/ucsbdiningcommonmenuitems").reply(200, {
+      axiosMock.onPut("/api/ucsbdiningcommonsmenuitems").reply(200, {
         id: "17",
         diningCommonsCode: "dining commons code 1",
         name: "name 1",

--- a/frontend/src/tests/pages/UCSBDiningCommonMenuItems/UCSBDiningCommonMenuItemsEditPage.test.jsx
+++ b/frontend/src/tests/pages/UCSBDiningCommonMenuItems/UCSBDiningCommonMenuItemsEditPage.test.jsx
@@ -46,7 +46,9 @@ describe("UCSBDiningCommonMenuItemsEditPage tests", () => {
       axiosMock
         .onGet("/api/systemInfo")
         .reply(200, systemInfoFixtures.showingNeither);
-      axiosMock.onGet("/api/ucsbdiningcommonmenuitems", { params: { id: 17 } }).timeout();
+      axiosMock
+        .onGet("/api/ucsbdiningcommonmenuitems", { params: { id: 17 } })
+        .timeout();
     });
 
     afterEach(() => {
@@ -88,12 +90,14 @@ describe("UCSBDiningCommonMenuItemsEditPage tests", () => {
       axiosMock
         .onGet("/api/systemInfo")
         .reply(200, systemInfoFixtures.showingNeither);
-      axiosMock.onGet("/api/ucsbdiningcommonmenuitems", { params: { id: 17 } }).reply(200, {
-        id: 17,
-        diningCommonsCode: "dining commons code 1",
-        name: "name 1",
-        station: "station 1",
-      });
+      axiosMock
+        .onGet("/api/ucsbdiningcommonmenuitems", { params: { id: 17 } })
+        .reply(200, {
+          id: 17,
+          diningCommonsCode: "dining commons code 1",
+          name: "name 1",
+          station: "station 1",
+        });
       axiosMock.onPut("/api/ucsbdiningcommonmenuitems").reply(200, {
         id: "17",
         diningCommonsCode: "dining commons code 1",
@@ -119,7 +123,9 @@ describe("UCSBDiningCommonMenuItemsEditPage tests", () => {
         </QueryClientProvider>,
       );
       await screen.findByText(/Welcome/);
-      await screen.findByTestId("UCSBDiningCommonMenuItemForm-diningCommonsCode");
+      await screen.findByTestId(
+        "UCSBDiningCommonMenuItemForm-diningCommonsCode",
+      );
       expect(
         screen.getByTestId("UCSBDiningCommonMenuItemForm-diningCommonsCode"),
       ).toBeInTheDocument();
@@ -134,13 +140,21 @@ describe("UCSBDiningCommonMenuItemsEditPage tests", () => {
         </QueryClientProvider>,
       );
 
-      await screen.findByTestId("UCSBDiningCommonMenuItemForm-diningCommonsCode");
+      await screen.findByTestId(
+        "UCSBDiningCommonMenuItemForm-diningCommonsCode",
+      );
 
       const idField = screen.getByTestId("UCSBDiningCommonMenuItemForm-id");
-      const diningCommonsCodeField = screen.getByTestId("UCSBDiningCommonMenuItemForm-diningCommonsCode");
+      const diningCommonsCodeField = screen.getByTestId(
+        "UCSBDiningCommonMenuItemForm-diningCommonsCode",
+      );
       const nameField = screen.getByTestId("UCSBDiningCommonMenuItemForm-name");
-      const stationField = screen.getByTestId("UCSBDiningCommonMenuItemForm-station");
-      const submitButton = screen.getByTestId("UCSBDiningCommonMenuItemForm-submit");
+      const stationField = screen.getByTestId(
+        "UCSBDiningCommonMenuItemForm-station",
+      );
+      const submitButton = screen.getByTestId(
+        "UCSBDiningCommonMenuItemForm-submit",
+      );
 
       expect(idField).toHaveValue("17");
       expect(diningCommonsCodeField).toHaveValue("dining commons code 1");
@@ -158,13 +172,21 @@ describe("UCSBDiningCommonMenuItemsEditPage tests", () => {
         </QueryClientProvider>,
       );
 
-      await screen.findByTestId("UCSBDiningCommonMenuItemForm-diningCommonsCode");
+      await screen.findByTestId(
+        "UCSBDiningCommonMenuItemForm-diningCommonsCode",
+      );
 
       const idField = screen.getByTestId("UCSBDiningCommonMenuItemForm-id");
-      const diningCommonsCodeField = screen.getByTestId("UCSBDiningCommonMenuItemForm-diningCommonsCode");
+      const diningCommonsCodeField = screen.getByTestId(
+        "UCSBDiningCommonMenuItemForm-diningCommonsCode",
+      );
       const nameField = screen.getByTestId("UCSBDiningCommonMenuItemForm-name");
-      const stationField = screen.getByTestId("UCSBDiningCommonMenuItemForm-station");
-      const submitButton = screen.getByTestId("UCSBDiningCommonMenuItemForm-submit");
+      const stationField = screen.getByTestId(
+        "UCSBDiningCommonMenuItemForm-station",
+      );
+      const submitButton = screen.getByTestId(
+        "UCSBDiningCommonMenuItemForm-submit",
+      );
 
       expect(idField).toHaveValue("17");
       expect(diningCommonsCodeField).toHaveValue("dining commons code 1");
@@ -173,7 +195,9 @@ describe("UCSBDiningCommonMenuItemsEditPage tests", () => {
 
       expect(submitButton).toBeInTheDocument();
 
-      fireEvent.change(diningCommonsCodeField, { target: { value: "dining commons code 1" } });
+      fireEvent.change(diningCommonsCodeField, {
+        target: { value: "dining commons code 1" },
+      });
       fireEvent.change(nameField, { target: { value: "name 1" } });
       fireEvent.change(stationField, { target: { value: "station 1" } });
 

--- a/frontend/src/tests/pages/UCSBDiningCommonMenuItems/UCSBDiningCommonMenuItemsEditPage.test.jsx
+++ b/frontend/src/tests/pages/UCSBDiningCommonMenuItems/UCSBDiningCommonMenuItemsEditPage.test.jsx
@@ -1,0 +1,199 @@
+import { fireEvent, render, waitFor, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router";
+import UCSBDiningCommonMenuItemsEditPage from "main/pages/UCSBDiningCommonMenuItems/UCSBDiningCommonMenuItemsEditPage";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+import mockConsole from "tests/testutils/mockConsole";
+import { beforeEach, afterEach } from "vitest";
+
+const mockToast = vi.fn();
+vi.mock("react-toastify", async (importOriginal) => {
+  const originalModule = await importOriginal();
+  return {
+    ...originalModule,
+    toast: vi.fn((x) => mockToast(x)),
+  };
+});
+
+const mockNavigate = vi.fn();
+vi.mock("react-router", async (importOriginal) => {
+  const originalModule = await importOriginal();
+  return {
+    ...originalModule,
+    useParams: vi.fn(() => ({
+      id: 17,
+    })),
+    Navigate: vi.fn((x) => {
+      mockNavigate(x);
+      return null;
+    }),
+  };
+});
+
+let axiosMock;
+describe("UCSBDiningCommonMenuItemsEditPage tests", () => {
+  describe("when the backend doesn't return data", () => {
+    beforeEach(() => {
+      axiosMock = new AxiosMockAdapter(axios);
+      axiosMock
+        .onGet("/api/currentUser")
+        .reply(200, apiCurrentUserFixtures.userOnly);
+      axiosMock
+        .onGet("/api/systemInfo")
+        .reply(200, systemInfoFixtures.showingNeither);
+      axiosMock.onGet("/api/ucsbdiningcommonmenuitems", { params: { id: 17 } }).timeout();
+    });
+
+    afterEach(() => {
+      mockToast.mockClear();
+      mockNavigate.mockClear();
+      axiosMock.restore();
+      axiosMock.resetHistory();
+    });
+
+    const queryClient = new QueryClient();
+    test("renders header but table is not present", async () => {
+      const restoreConsole = mockConsole();
+
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <UCSBDiningCommonMenuItemsEditPage />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+
+      await screen.findByText(/Welcome/);
+      await screen.findByText("Edit UCSBDiningCommonMenuItem");
+      expect(
+        screen.queryByTestId("UCSBDiningCommonMenuItemForm-diningCommonsCode"),
+      ).not.toBeInTheDocument();
+      restoreConsole();
+    });
+  });
+
+  describe("tests where backend is working normally", () => {
+    beforeEach(() => {
+      axiosMock = new AxiosMockAdapter(axios);
+      axiosMock.reset();
+      axiosMock.resetHistory();
+      axiosMock
+        .onGet("/api/currentUser")
+        .reply(200, apiCurrentUserFixtures.userOnly);
+      axiosMock
+        .onGet("/api/systemInfo")
+        .reply(200, systemInfoFixtures.showingNeither);
+      axiosMock.onGet("/api/ucsbdiningcommonmenuitems", { params: { id: 17 } }).reply(200, {
+        id: 17,
+        diningCommonsCode: "dining commons code 1",
+        name: "name 1",
+        station: "station 1",
+      });
+      axiosMock.onPut("/api/ucsbdiningcommonmenuitems").reply(200, {
+        id: "17",
+        diningCommonsCode: "dining commons code 1",
+        name: "name 1",
+        station: "station 1",
+      });
+    });
+
+    afterEach(() => {
+      mockToast.mockClear();
+      mockNavigate.mockClear();
+      axiosMock.restore();
+      axiosMock.resetHistory();
+    });
+
+    const queryClient = new QueryClient();
+    test("renders without crashing", async () => {
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <UCSBDiningCommonMenuItemsEditPage />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+      await screen.findByText(/Welcome/);
+      await screen.findByTestId("UCSBDiningCommonMenuItemForm-diningCommonsCode");
+      expect(
+        screen.getByTestId("UCSBDiningCommonMenuItemForm-diningCommonsCode"),
+      ).toBeInTheDocument();
+    });
+
+    test("Is populated with the data provided", async () => {
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <UCSBDiningCommonMenuItemsEditPage />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+
+      await screen.findByTestId("UCSBDiningCommonMenuItemForm-diningCommonsCode");
+
+      const idField = screen.getByTestId("UCSBDiningCommonMenuItemForm-id");
+      const diningCommonsCodeField = screen.getByTestId("UCSBDiningCommonMenuItemForm-diningCommonsCode");
+      const nameField = screen.getByTestId("UCSBDiningCommonMenuItemForm-name");
+      const stationField = screen.getByTestId("UCSBDiningCommonMenuItemForm-station");
+      const submitButton = screen.getByTestId("UCSBDiningCommonMenuItemForm-submit");
+
+      expect(idField).toHaveValue("17");
+      expect(diningCommonsCodeField).toHaveValue("dining commons code 1");
+      expect(nameField).toHaveValue("name 1");
+      expect(stationField).toHaveValue("station 1");
+      expect(submitButton).toBeInTheDocument();
+    });
+
+    test("Changes when you click Update", async () => {
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <UCSBDiningCommonMenuItemsEditPage />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+
+      await screen.findByTestId("UCSBDiningCommonMenuItemForm-diningCommonsCode");
+
+      const idField = screen.getByTestId("UCSBDiningCommonMenuItemForm-id");
+      const diningCommonsCodeField = screen.getByTestId("UCSBDiningCommonMenuItemForm-diningCommonsCode");
+      const nameField = screen.getByTestId("UCSBDiningCommonMenuItemForm-name");
+      const stationField = screen.getByTestId("UCSBDiningCommonMenuItemForm-station");
+      const submitButton = screen.getByTestId("UCSBDiningCommonMenuItemForm-submit");
+
+      expect(idField).toHaveValue("17");
+      expect(diningCommonsCodeField).toHaveValue("dining commons code 1");
+      expect(nameField).toHaveValue("name 1");
+      expect(stationField).toHaveValue("station 1");
+
+      expect(submitButton).toBeInTheDocument();
+
+      fireEvent.change(diningCommonsCodeField, { target: { value: "dining commons code 1" } });
+      fireEvent.change(nameField, { target: { value: "name 1" } });
+      fireEvent.change(stationField, { target: { value: "station 1" } });
+
+      fireEvent.click(submitButton);
+
+      await waitFor(() => expect(mockToast).toBeCalled());
+      expect(mockToast).toBeCalledWith(
+        "UCSBDiningCommonMenuItem Updated - id: 17 diningCommonsCode: dining commons code 1 name: name 1 station: station 1",
+      );
+      expect(mockNavigate).toBeCalledWith({ to: "/ucsbdiningcommonmenuitems" });
+
+      expect(axiosMock.history.put.length).toBe(1); // times called
+      expect(axiosMock.history.put[0].params).toEqual({ id: 17 });
+      expect(axiosMock.history.put[0].data).toBe(
+        JSON.stringify({
+          diningCommonsCode: "dining commons code 1",
+          name: "name 1",
+          station: "station 1",
+        }),
+      ); // posted object
+    });
+  });
+});

--- a/frontend/src/tests/pages/UCSBDiningCommonMenuItems/UCSBDiningCommonMenuItemsIndexPage.test.jsx
+++ b/frontend/src/tests/pages/UCSBDiningCommonMenuItems/UCSBDiningCommonMenuItemsIndexPage.test.jsx
@@ -63,7 +63,9 @@ describe("UCSBDiningCommonMenuItemsIndexPage tests", () => {
 
     // assert
     await waitFor(() => {
-      expect(screen.getByText(/Create UCSBDiningCommonMenuItem/)).toBeInTheDocument();
+      expect(
+        screen.getByText(/Create UCSBDiningCommonMenuItem/),
+      ).toBeInTheDocument();
     });
     const button = screen.getByText(/Create UCSBDiningCommonMenuItem/);
     expect(button).toHaveAttribute("href", "/ucsbdiningcommonmenuitems/create");
@@ -101,7 +103,9 @@ describe("UCSBDiningCommonMenuItemsIndexPage tests", () => {
     );
 
     // assert that the Create button is not present when user isn't an admin
-    expect(screen.queryByText(/Create UCSBDiningCommonMenuItem/)).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/Create UCSBDiningCommonMenuItem/),
+    ).not.toBeInTheDocument();
   });
 
   test("renders empty table when backend unavailable, user only", async () => {
@@ -177,7 +181,9 @@ describe("UCSBDiningCommonMenuItemsIndexPage tests", () => {
 
     // assert
     await waitFor(() => {
-      expect(mockToast).toBeCalledWith("UCSBDiningCommonMenuItem with id 1 was deleted");
+      expect(mockToast).toBeCalledWith(
+        "UCSBDiningCommonMenuItem with id 1 was deleted",
+      );
     });
   });
 });

--- a/frontend/src/tests/pages/UCSBDiningCommonMenuItems/UCSBDiningCommonMenuItemsIndexPage.test.jsx
+++ b/frontend/src/tests/pages/UCSBDiningCommonMenuItems/UCSBDiningCommonMenuItemsIndexPage.test.jsx
@@ -1,0 +1,183 @@
+import { fireEvent, render, waitFor, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router";
+import UCSBDiningCommonMenuItemsIndexPage from "main/pages/UCSBDiningCommonMenuItems/UCSBDiningCommonMenuItemsIndexPage";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { ucsbDiningCommonMenuItemsFixtures } from "fixtures/ucsbDiningCommonMenuItemsFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+import mockConsole from "tests/testutils/mockConsole";
+
+const mockToast = vi.fn();
+vi.mock("react-toastify", async (importOriginal) => {
+  const originalModule = await importOriginal();
+  return {
+    ...originalModule,
+    toast: vi.fn((x) => mockToast(x)),
+  };
+});
+
+describe("UCSBDiningCommonMenuItemsIndexPage tests", () => {
+  const axiosMock = new AxiosMockAdapter(axios);
+
+  const testId = "UCSBDiningCommonMenuItemsTable";
+
+  const setupUserOnly = () => {
+    axiosMock.reset();
+    axiosMock.resetHistory();
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.userOnly);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+  };
+
+  const setupAdminUser = () => {
+    axiosMock.reset();
+    axiosMock.resetHistory();
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.adminUser);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+  };
+
+  test("Renders with Create Button for admin user", async () => {
+    // arrange
+    setupAdminUser();
+    const queryClient = new QueryClient();
+    axiosMock.onGet("/api/ucsbdiningcommonmenuitems/all").reply(200, []);
+
+    // act
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <UCSBDiningCommonMenuItemsIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    // assert
+    await waitFor(() => {
+      expect(screen.getByText(/Create UCSBDiningCommonMenuItem/)).toBeInTheDocument();
+    });
+    const button = screen.getByText(/Create UCSBDiningCommonMenuItem/);
+    expect(button).toHaveAttribute("href", "/ucsbdiningcommonmenuitems/create");
+    expect(button).toHaveAttribute("style", "float: right;");
+  });
+
+  test("renders three menu items correctly for regular user", async () => {
+    // arrange
+    setupUserOnly();
+    const queryClient = new QueryClient();
+    axiosMock
+      .onGet("/api/ucsbdiningcommonmenuitems/all")
+      .reply(200, ucsbDiningCommonMenuItemsFixtures.threeMenuItems);
+
+    // act
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <UCSBDiningCommonMenuItemsIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    // assert
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(`${testId}-cell-row-0-col-id`),
+      ).toHaveTextContent("1");
+    });
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent(
+      "2",
+    );
+    expect(screen.getByTestId(`${testId}-cell-row-2-col-id`)).toHaveTextContent(
+      "3",
+    );
+
+    // assert that the Create button is not present when user isn't an admin
+    expect(screen.queryByText(/Create UCSBDiningCommonMenuItem/)).not.toBeInTheDocument();
+  });
+
+  test("renders empty table when backend unavailable, user only", async () => {
+    // arrange
+    setupUserOnly();
+    const queryClient = new QueryClient();
+    axiosMock.onGet("/api/ucsbdiningcommonmenuitems/all").timeout();
+    const restoreConsole = mockConsole();
+
+    // act
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <UCSBDiningCommonMenuItemsIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    // assert
+    await waitFor(() => {
+      expect(axiosMock.history.get.length).toBeGreaterThanOrEqual(1);
+    });
+
+    const errorMessage = console.error.mock.calls[0][0];
+    expect(errorMessage).toMatch(
+      "Error communicating with backend via GET on /api/ucsbdiningcommonmenuitems/all",
+    );
+    restoreConsole();
+
+    expect(
+      screen.queryByTestId(`${testId}-cell-row-0-col-id`),
+    ).not.toBeInTheDocument();
+  });
+
+  test("what happens when you click delete, admin", async () => {
+    // arrange
+    setupAdminUser();
+    const queryClient = new QueryClient();
+    axiosMock
+      .onGet("/api/ucsbdiningcommonmenuitems/all")
+      .reply(200, ucsbDiningCommonMenuItemsFixtures.threeMenuItems);
+    axiosMock
+      .onDelete("/api/ucsbdiningcommonmenuitems")
+      .reply(200, "UCSBDiningCommonMenuItem with id 1 was deleted");
+
+    // act
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <UCSBDiningCommonMenuItemsIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    // assert
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(`${testId}-cell-row-0-col-id`),
+      ).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent(
+      "1",
+    );
+
+    const deleteButton = screen.getByTestId(
+      `${testId}-cell-row-0-col-Delete-button`,
+    );
+    expect(deleteButton).toBeInTheDocument();
+
+    // act
+    fireEvent.click(deleteButton);
+
+    // assert
+    await waitFor(() => {
+      expect(mockToast).toBeCalledWith("UCSBDiningCommonMenuItem with id 1 was deleted");
+    });
+  });
+});

--- a/frontend/src/tests/pages/UCSBDiningCommonMenuItems/UCSBDiningCommonMenuItemsIndexPage.test.jsx
+++ b/frontend/src/tests/pages/UCSBDiningCommonMenuItems/UCSBDiningCommonMenuItemsIndexPage.test.jsx
@@ -50,7 +50,7 @@ describe("UCSBDiningCommonMenuItemsIndexPage tests", () => {
     // arrange
     setupAdminUser();
     const queryClient = new QueryClient();
-    axiosMock.onGet("/api/ucsbdiningcommonmenuitems/all").reply(200, []);
+    axiosMock.onGet("/api/ucsbdiningcommonsmenuitems/all").reply(200, []);
 
     // act
     render(
@@ -77,7 +77,7 @@ describe("UCSBDiningCommonMenuItemsIndexPage tests", () => {
     setupUserOnly();
     const queryClient = new QueryClient();
     axiosMock
-      .onGet("/api/ucsbdiningcommonmenuitems/all")
+      .onGet("/api/ucsbdiningcommonsmenuitems/all")
       .reply(200, ucsbDiningCommonMenuItemsFixtures.threeMenuItems);
 
     // act
@@ -112,7 +112,7 @@ describe("UCSBDiningCommonMenuItemsIndexPage tests", () => {
     // arrange
     setupUserOnly();
     const queryClient = new QueryClient();
-    axiosMock.onGet("/api/ucsbdiningcommonmenuitems/all").timeout();
+    axiosMock.onGet("/api/ucsbdiningcommonsmenuitems/all").timeout();
     const restoreConsole = mockConsole();
 
     // act
@@ -131,7 +131,7 @@ describe("UCSBDiningCommonMenuItemsIndexPage tests", () => {
 
     const errorMessage = console.error.mock.calls[0][0];
     expect(errorMessage).toMatch(
-      "Error communicating with backend via GET on /api/ucsbdiningcommonmenuitems/all",
+      "Error communicating with backend via GET on /api/ucsbdiningcommonsmenuitems/all",
     );
     restoreConsole();
 
@@ -145,10 +145,10 @@ describe("UCSBDiningCommonMenuItemsIndexPage tests", () => {
     setupAdminUser();
     const queryClient = new QueryClient();
     axiosMock
-      .onGet("/api/ucsbdiningcommonmenuitems/all")
+      .onGet("/api/ucsbdiningcommonsmenuitems/all")
       .reply(200, ucsbDiningCommonMenuItemsFixtures.threeMenuItems);
     axiosMock
-      .onDelete("/api/ucsbdiningcommonmenuitems")
+      .onDelete("/api/ucsbdiningcommonsmenuitems")
       .reply(200, "UCSBDiningCommonMenuItem with id 1 was deleted");
 
     // act

--- a/frontend/src/tests/utils/UCSBDiningCommonMenuItemUtils.test.js
+++ b/frontend/src/tests/utils/UCSBDiningCommonMenuItemUtils.test.js
@@ -41,7 +41,7 @@ describe("UCSBDiningCommonMenuItemUtils", () => {
 
       // assert
       expect(result).toEqual({
-        url: "/api/ucsbdiningcommonmenuitems",
+        url: "/api/ucsbdiningcommonsmenuitems",
         method: "DELETE",
         params: { id: 17 },
       });


### PR DESCRIPTION
Closes #6, Closes #7, Closes #8, Closes #9 

The three pages are all functioning correctly. 
- Create would allow admin to create new MenuItem if all entries are non-empty, and would successfully pass to database.
- Edit page would allow admin to edit a MenuItem if all entries are non-empty, and would successfully update in database.
- Index page would pull all items in database, and would auto-refresh when new changes are made. It also shows edit and delete button for only admins.

Link to storybook:
https://69f413a1c2ee91ec24c6314d-lbzbersklk.chromatic.com/?path=/story/pages-ucsbdiningcommonmenuitems-ucsbdiningcommonmenuitemscreatepage--default

Link to personal deployment of the branch:


Screenshot of the create/edit/index pages:
<img width="1802" height="452" alt="image" src="https://github.com/user-attachments/assets/b8700184-2414-43c1-bec4-992ab9b12370" />
<img width="1903" height="577" alt="image" src="https://github.com/user-attachments/assets/a4aaba0f-2a5f-477c-9257-72313772f47b" />
<img width="1844" height="613" alt="image" src="https://github.com/user-attachments/assets/86cb53a1-e9db-4ea1-9c84-842f3f420434" />
