### PR TITLE
Sherwin - Table Component for HelpRequest plus Tests

### DIFF
--- a/frontend/src/main/components/HelpRequests/HelpRequestTable.jsx
+++ b/frontend/src/main/components/HelpRequests/HelpRequestTable.jsx
@@ -1,0 +1,78 @@
+import React from "react";
+import OurTable, { ButtonColumn } from "main/components/OurTable";
+
+import { useBackendMutation } from "main/utils/useBackend";
+import {
+  cellToAxiosParamsDelete,
+  onDeleteSuccess,
+} from "main/utils/helpRequestUtils";
+import { useNavigate } from "react-router";
+import { hasRole } from "main/utils/useCurrentUser";
+
+export default function HelpRequestTable({
+  helprequests,
+  currentUser,
+  testIdPrefix = "HelpRequestTable",
+}) {
+  const navigate = useNavigate();
+
+  const editCallback = (cell) => {
+    navigate(`/helprequests/edit/${cell.row.original.id}`);
+  };
+
+  // Stryker disable all : hard to test for query caching
+
+  const deleteMutation = useBackendMutation(
+    cellToAxiosParamsDelete,
+    { onSuccess: onDeleteSuccess },
+    ["/api/helprequests/all"],
+  );
+  // Stryker restore all
+
+  // Stryker disable next-line all : TODO try to make a good test for this
+  const deleteCallback = async (cell) => {
+    deleteMutation.mutate(cell);
+  };
+
+  const columns = [
+    {
+      header: "id",
+      accessorKey: "id", // accessor is the "key" in the data
+    },
+    {
+      header: "Requester Email",
+      accessorKey: "requesterEmail",
+    },
+    {
+      header: "Team ID",
+      accessorKey: "teamId",
+    },
+    {
+      header: "Table or Breakout Room",
+      accessorKey: "tableOrBreakoutRoom",
+    },
+    {
+      header: "Request Time",
+      accessorKey: "requestTime",
+    },
+    {
+      header: "Explanation",
+      accessorKey: "explanation",
+    },
+    {
+      header: "Solved",
+      accessorKey: "solved",
+    },
+  ];
+
+  if (hasRole(currentUser, "ROLE_ADMIN")) {
+    columns.push(ButtonColumn("Edit", "primary", editCallback, testIdPrefix));
+    columns.push(
+      ButtonColumn("Delete", "danger", deleteCallback, testIdPrefix),
+    );
+  }
+
+  return (
+    <OurTable data={helprequests} columns={columns} testid={testIdPrefix} />
+  );
+}

--- a/frontend/src/main/utils/helpRequestUtils.js
+++ b/frontend/src/main/utils/helpRequestUtils.js
@@ -1,0 +1,16 @@
+import { toast } from "react-toastify";
+
+export function onDeleteSuccess(message) {
+  console.log(message);
+  toast(message);
+}
+
+export function cellToAxiosParamsDelete(cell) {
+  return {
+    url: "/api/helprequests",
+    method: "DELETE",
+    params: {
+      id: cell.row.original.id,
+    },
+  };
+}

--- a/frontend/src/stories/components/HelpRequests/HelpRequestTable.stories.jsx
+++ b/frontend/src/stories/components/HelpRequests/HelpRequestTable.stories.jsx
@@ -1,0 +1,41 @@
+import React from "react";
+import HelpRequestTable from "main/components/HelpRequests/HelpRequestTable";
+import { helpRequestFixtures } from "fixtures/helpRequestFixtures";
+import { currentUserFixtures } from "fixtures/currentUserFixtures";
+import { http, HttpResponse } from "msw";
+
+export default {
+  title: "components/HelpRequests/HelpRequestTable",
+  component: HelpRequestTable,
+};
+
+const Template = (args) => {
+  return <HelpRequestTable {...args} />;
+};
+
+export const Empty = Template.bind({});
+
+Empty.args = {
+  helprequests: [],
+};
+
+export const ThreeItemsOrdinaryUser = Template.bind({});
+
+ThreeItemsOrdinaryUser.args = {
+  helprequests: helpRequestFixtures.threeHelpRequests,
+  currentUser: currentUserFixtures.userOnly,
+};
+
+export const ThreeItemsAdminUser = Template.bind({});
+ThreeItemsAdminUser.args = {
+  helprequests: helpRequestFixtures.threeHelpRequests,
+  currentUser: currentUserFixtures.adminUser,
+};
+
+ThreeItemsAdminUser.parameters = {
+  msw: [
+    http.delete("/api/helprequests", () => {
+      return HttpResponse.json({}, { status: 200 });
+    }),
+  ],
+};

--- a/frontend/src/tests/components/HelpRequests/HelpRequestTable.test.jsx
+++ b/frontend/src/tests/components/HelpRequests/HelpRequestTable.test.jsx
@@ -232,8 +232,8 @@ describe("HelpRequestTable tests", () => {
   });
 
   test("onDeleteSuccess calls toast with the message", () => {
-  onDeleteSuccess("Help Request deleted");
+    onDeleteSuccess("Help Request deleted");
 
-  expect(toast).toHaveBeenCalledWith("Help Request deleted");
-});
+    expect(toast).toHaveBeenCalledWith("Help Request deleted");
+  });
 });

--- a/frontend/src/tests/components/HelpRequests/HelpRequestTable.test.jsx
+++ b/frontend/src/tests/components/HelpRequests/HelpRequestTable.test.jsx
@@ -6,6 +6,8 @@ import { currentUserFixtures } from "fixtures/currentUserFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
 import { helpRequestFixtures } from "fixtures/helpRequestFixtures";
+import { toast } from "react-toastify";
+import { onDeleteSuccess } from "main/utils/helpRequestUtils";
 
 const mockedNavigate = vi.fn();
 vi.mock("react-router", async () => {
@@ -13,6 +15,14 @@ vi.mock("react-router", async () => {
   return {
     ...originalModule,
     useNavigate: () => mockedNavigate,
+  };
+});
+
+vi.mock("react-toastify", async () => {
+  const originalModule = await vi.importActual("react-toastify");
+  return {
+    ...originalModule,
+    toast: vi.fn(),
   };
 });
 
@@ -217,6 +227,13 @@ describe("HelpRequestTable tests", () => {
     // assert - check that the delete endpoint was called
 
     await waitFor(() => expect(axiosMock.history.delete.length).toBe(1));
+    expect(axiosMock.history.delete[0].url).toBe("/api/helprequests");
     expect(axiosMock.history.delete[0].params).toEqual({ id: 1 });
   });
+
+  test("onDeleteSuccess calls toast with the message", () => {
+  onDeleteSuccess("Help Request deleted");
+
+  expect(toast).toHaveBeenCalledWith("Help Request deleted");
+});
 });

--- a/frontend/src/tests/components/HelpRequests/HelpRequestTable.test.jsx
+++ b/frontend/src/tests/components/HelpRequests/HelpRequestTable.test.jsx
@@ -1,0 +1,222 @@
+import { fireEvent, render, waitFor, screen } from "@testing-library/react";
+import HelpRequestTable from "main/components/HelpRequests/HelpRequestTable";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router";
+import { currentUserFixtures } from "fixtures/currentUserFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+import { helpRequestFixtures } from "fixtures/helpRequestFixtures";
+
+const mockedNavigate = vi.fn();
+vi.mock("react-router", async () => {
+  const originalModule = await vi.importActual("react-router");
+  return {
+    ...originalModule,
+    useNavigate: () => mockedNavigate,
+  };
+});
+
+describe("HelpRequestTable tests", () => {
+  const queryClient = new QueryClient();
+
+  test("Has the expected column headers and content for ordinary user", () => {
+    const currentUser = currentUserFixtures.userOnly;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <HelpRequestTable
+            helprequests={helpRequestFixtures.threeHelpRequests}
+            currentUser={currentUser}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    const expectedHeaders = [
+      "id",
+      "Requester Email",
+      "Team ID",
+      "Table or Breakout Room",
+      "Request Time",
+      "Explanation",
+      "Solved",
+    ];
+    const expectedFields = [
+      "id",
+      "requesterEmail",
+      "teamId",
+      "tableOrBreakoutRoom",
+      "requestTime",
+      "explanation",
+      "solved",
+    ];
+    const testId = "HelpRequestTable";
+
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expectedFields.forEach((field) => {
+      const header = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
+      expect(header).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent(
+      "1",
+    );
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent(
+      "2",
+    );
+
+    const editButton = screen.queryByTestId(
+      `${testId}-cell-row-0-col-Edit-button`,
+    );
+    expect(editButton).not.toBeInTheDocument();
+
+    const deleteButton = screen.queryByTestId(
+      `${testId}-cell-row-0-col-Delete-button`,
+    );
+    expect(deleteButton).not.toBeInTheDocument();
+  });
+
+  test("Has the expected colum headers and content for adminUser", () => {
+    const currentUser = currentUserFixtures.adminUser;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <HelpRequestTable
+            helprequests={helpRequestFixtures.threeHelpRequests}
+            currentUser={currentUser}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    const expectedHeaders = [
+      "id",
+      "Requester Email",
+      "Team ID",
+      "Table or Breakout Room",
+      "Request Time",
+      "Explanation",
+      "Solved",
+    ];
+    const expectedFields = [
+      "id",
+      "requesterEmail",
+      "teamId",
+      "tableOrBreakoutRoom",
+      "requestTime",
+      "explanation",
+      "solved",
+    ];
+    const testId = "HelpRequestTable";
+
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expectedFields.forEach((field) => {
+      const header = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
+      expect(header).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent(
+      "1",
+    );
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent(
+      "2",
+    );
+
+    const editButton = screen.getByTestId(
+      `${testId}-cell-row-0-col-Edit-button`,
+    );
+    expect(editButton).toBeInTheDocument();
+    expect(editButton).toHaveClass("btn-primary");
+
+    const deleteButton = screen.getByTestId(
+      `${testId}-cell-row-0-col-Delete-button`,
+    );
+    expect(deleteButton).toBeInTheDocument();
+    expect(deleteButton).toHaveClass("btn-danger");
+  });
+
+  test("Edit button navigates to the edit page for admin user", async () => {
+    const currentUser = currentUserFixtures.adminUser;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <HelpRequestTable
+            helprequests={helpRequestFixtures.threeHelpRequests}
+            currentUser={currentUser}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(`HelpRequestTable-cell-row-0-col-id`),
+      ).toHaveTextContent("1");
+    });
+
+    const editButton = screen.getByTestId(
+      `HelpRequestTable-cell-row-0-col-Edit-button`,
+    );
+    expect(editButton).toBeInTheDocument();
+
+    fireEvent.click(editButton);
+
+    await waitFor(() =>
+      expect(mockedNavigate).toHaveBeenCalledWith("/helprequests/edit/1"),
+    );
+  });
+
+  test("Delete button calls delete callback", async () => {
+    // arrange
+    const currentUser = currentUserFixtures.adminUser;
+
+    const axiosMock = new AxiosMockAdapter(axios);
+    axiosMock
+      .onDelete("/api/helprequests")
+      .reply(200, { message: "Help Request deleted" });
+
+    // act - render the component
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <HelpRequestTable
+            helprequests={helpRequestFixtures.threeHelpRequests}
+            currentUser={currentUser}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    // assert - check that the expected content is rendered
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(`HelpRequestTable-cell-row-0-col-id`),
+      ).toHaveTextContent("1");
+    });
+
+    const deleteButton = screen.getByTestId(
+      `HelpRequestTable-cell-row-0-col-Delete-button`,
+    );
+    expect(deleteButton).toBeInTheDocument();
+
+    // act - click the delete button
+    fireEvent.click(deleteButton);
+
+    // assert - check that the delete endpoint was called
+
+    await waitFor(() => expect(axiosMock.history.delete.length).toBe(1));
+    expect(axiosMock.history.delete[0].params).toEqual({ id: 1 });
+  });
+});


### PR DESCRIPTION
This PR creates a new table component for HelpRequests as well as tests.

Empty
<img width="1008" height="158" alt="image" src="https://github.com/user-attachments/assets/744a63e4-5786-49e7-aae5-2f9022bf4ac4" />

Three Items Ordinary User
<img width="887" height="185" alt="image" src="https://github.com/user-attachments/assets/f8a853e6-1b8d-4f7e-91c3-c94b86a0738d" />

Three Items Admin User
<img width="893" height="321" alt="image" src="https://github.com/user-attachments/assets/91447a27-d163-4776-bc92-c1e8e9766648" />

Closes: #41 