### PR TITLE
Add UCSBOrganization edit and index pages

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -147,7 +147,7 @@ function App() {
         <>
           <Route
             exact
-            path="/ucsborganizations/edit/:id"
+            path="/ucsborganizations/edit/:orgCode"
             element={<UCSBOrganizationEditPage />}
           />
           <Route

--- a/frontend/src/main/components/UCSBOrganization/UCSBOrganizationTable.jsx
+++ b/frontend/src/main/components/UCSBOrganization/UCSBOrganizationTable.jsx
@@ -16,7 +16,7 @@ export default function UCSBOrganizationTable({
   const navigate = useNavigate();
 
   const editCallback = (cell) => {
-    navigate(`/ucsborganization/edit/${cell.row.original.orgCode}`);
+    navigate(`/ucsborganizations/edit/${cell.row.original.orgCode}`);
   };
 
   // Stryker disable all : hard to test for query caching

--- a/frontend/src/main/pages/UCSBOrganization/UCSBOrganizationEditPage.jsx
+++ b/frontend/src/main/pages/UCSBOrganization/UCSBOrganizationEditPage.jsx
@@ -1,11 +1,77 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import { useParams } from "react-router";
+import UCSBOrganizationForm from "main/components/UCSBOrganization/UCSBOrganizationForm";
+import { Navigate } from "react-router";
+import { useBackend, useBackendMutation } from "main/utils/useBackend";
+import { toast } from "react-toastify";
 
-export default function UCSBOrganizationEditPage() {
-  // Stryker disable all : placeholder page
+export default function UCSBOrganizationEditPage({ storybook = false }) {
+  let { orgCode } = useParams();
+
+  const {
+    data: ucsbOrganization,
+    _error,
+    _status,
+  } = useBackend(
+    // Stryker disable next-line all : don't test internal caching of React Query
+    [`/api/UCSBOrganization?code=${orgCode}`],
+    {
+      // Stryker disable next-line all : GET is the default, so changing this to "" doesn't introduce a bug
+      method: "GET",
+      url: `/api/UCSBOrganization`,
+      params: {
+        code: orgCode,
+      },
+    },
+  );
+
+  const objectToAxiosPutParams = (ucsbOrganization) => ({
+    url: "/api/UCSBOrganization",
+    method: "PUT",
+    params: {
+      code: ucsbOrganization.orgCode,
+    },
+    data: {
+      orgTranslationShort: ucsbOrganization.orgTranslationShort,
+      orgTranslation: ucsbOrganization.orgTranslation,
+      inactive: ucsbOrganization.inactive,
+    },
+  });
+
+  const onSuccess = (ucsbOrganization) => {
+    toast(
+      `UCSBOrganization Updated - orgCode: ${ucsbOrganization.orgCode} orgTranslationShort: ${ucsbOrganization.orgTranslationShort} orgTranslation: ${ucsbOrganization.orgTranslation} inactive: ${ucsbOrganization.inactive}`,
+    );
+  };
+
+  const mutation = useBackendMutation(
+    objectToAxiosPutParams,
+    { onSuccess },
+    // Stryker disable next-line all : hard to set up test for caching
+    [`/api/UCSBOrganization?code=${orgCode}`],
+  );
+
+  const { isSuccess } = mutation;
+
+  const onSubmit = async (data) => {
+    mutation.mutate(data);
+  };
+
+  if (isSuccess && !storybook) {
+    return <Navigate to="/ucsborganizations" />;
+  }
+
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Edit page not yet implemented</h1>
+        <h1>Edit UCSBOrganization</h1>
+        {ucsbOrganization && (
+          <UCSBOrganizationForm
+            initialContents={ucsbOrganization}
+            submitAction={onSubmit}
+            buttonLabel="Update"
+          />
+        )}
       </div>
     </BasicLayout>
   );

--- a/frontend/src/main/pages/UCSBOrganization/UCSBOrganizationEditPage.jsx
+++ b/frontend/src/main/pages/UCSBOrganization/UCSBOrganizationEditPage.jsx
@@ -20,7 +20,7 @@ export default function UCSBOrganizationEditPage({ storybook = false }) {
       method: "GET",
       url: `/api/UCSBOrganization`,
       params: {
-        code: orgCode,
+        orgCode,
       },
     },
   );
@@ -29,7 +29,7 @@ export default function UCSBOrganizationEditPage({ storybook = false }) {
     url: "/api/UCSBOrganization",
     method: "PUT",
     params: {
-      code: ucsbOrganization.orgCode,
+      orgCode: ucsbOrganization.orgCode,
     },
     data: {
       orgTranslationShort: ucsbOrganization.orgTranslationShort,
@@ -48,7 +48,7 @@ export default function UCSBOrganizationEditPage({ storybook = false }) {
     objectToAxiosPutParams,
     { onSuccess },
     // Stryker disable next-line all : hard to set up test for caching
-    [`/api/UCSBOrganization?code=${orgCode}`],
+    [`/api/UCSBOrganization?orgCode=${orgCode}`],
   );
 
   const { isSuccess } = mutation;

--- a/frontend/src/main/pages/UCSBOrganization/UCSBOrganizationIndexPage.jsx
+++ b/frontend/src/main/pages/UCSBOrganization/UCSBOrganizationIndexPage.jsx
@@ -1,18 +1,48 @@
+import React from "react";
+import { useBackend } from "main/utils/useBackend";
+
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
-import { Link } from "react-router";
+import UCSBOrganizationTable from "main/components/UCSBOrganization/UCSBOrganizationTable";
+import { Button } from "react-bootstrap";
+import { useCurrentUser, hasRole } from "main/utils/useCurrentUser";
 
 export default function UCSBOrganizationIndexPage() {
-  // Stryker disable all : placeholder page
+  const currentUser = useCurrentUser();
+
+  const createButton = () => {
+    if (hasRole(currentUser, "ROLE_ADMIN")) {
+      return (
+        <Button
+          variant="primary"
+          href="/ucsborganizations/create"
+          style={{ float: "right" }}
+        >
+          Create UCSBOrganization
+        </Button>
+      );
+    }
+  };
+
+  const {
+    data: ucsbOrganizations,
+    error: _error,
+    status: _status,
+  } = useBackend(
+    // Stryker disable next-line all : don't test internal caching of React Query
+    ["/api/UCSBOrganization/all"],
+    { method: "GET", url: "/api/UCSBOrganization/all" },
+    [],
+  );
+
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Index page not yet implemented</h1>
-        <p>
-          <Link to="/ucsborganizations/create">Create</Link>
-        </p>
-        <p>
-          <Link to="/ucsborganizations/edit/DSClub">Edit</Link>
-        </p>
+        {createButton()}
+        <h1>UCSBOrganizations</h1>
+        <UCSBOrganizationTable
+          ucsbOrganizations={ucsbOrganizations}
+          currentUser={currentUser}
+        />
       </div>
     </BasicLayout>
   );

--- a/frontend/src/stories/pages/UCSBOrganization/UCSBOrganizationEditPage.stories.jsx
+++ b/frontend/src/stories/pages/UCSBOrganization/UCSBOrganizationEditPage.stories.jsx
@@ -1,0 +1,47 @@
+import React from "react";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { ucsbOrganizationFixtures } from "fixtures/ucsbOrganizationFixtures";
+import { http, HttpResponse } from "msw";
+
+import UCSBOrganizationEditPage from "main/pages/UCSBOrganization/UCSBOrganizationEditPage";
+
+export default {
+  title: "pages/UCSBOrganization/UCSBOrganizationEditPage",
+  component: UCSBOrganizationEditPage,
+};
+
+const Template = () => <UCSBOrganizationEditPage storybook={true} />;
+
+export const Default = Template.bind({});
+
+Default.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.userOnly, {
+        status: 200,
+      });
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither, {
+        status: 200,
+      });
+    }),
+    http.get("/api/UCSBOrganization", () => {
+      return HttpResponse.json(ucsbOrganizationFixtures.oneOrganization[0], {
+        status: 200,
+      });
+    }),
+    http.put("/api/UCSBOrganization", () => {
+      return HttpResponse.json(
+        {
+          orgCode: "DSClub",
+          orgTranslationShort: "DSC",
+          orgTranslation: "Data Science Club",
+          inactive: false,
+        },
+        { status: 200 },
+      );
+    }),
+  ],
+};

--- a/frontend/src/stories/pages/UCSBOrganization/UCSBOrganizationIndexPage.stories.jsx
+++ b/frontend/src/stories/pages/UCSBOrganization/UCSBOrganizationIndexPage.stories.jsx
@@ -1,0 +1,69 @@
+import React from "react";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { ucsbOrganizationFixtures } from "fixtures/ucsbOrganizationFixtures";
+import { http, HttpResponse } from "msw";
+
+import UCSBOrganizationIndexPage from "main/pages/UCSBOrganization/UCSBOrganizationIndexPage";
+
+export default {
+  title: "pages/UCSBOrganization/UCSBOrganizationIndexPage",
+  component: UCSBOrganizationIndexPage,
+};
+
+const Template = () => <UCSBOrganizationIndexPage storybook={true} />;
+
+export const Empty = Template.bind({});
+
+Empty.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.userOnly, {
+        status: 200,
+      });
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither, {
+        status: 200,
+      });
+    }),
+    http.get("/api/UCSBOrganization/all", () => {
+      return HttpResponse.json([], { status: 200 });
+    }),
+  ],
+};
+
+export const ThreeItemsOrdinaryUser = Template.bind({});
+
+ThreeItemsOrdinaryUser.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.userOnly);
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither);
+    }),
+    http.get("/api/UCSBOrganization/all", () => {
+      return HttpResponse.json(ucsbOrganizationFixtures.threeOrganizations);
+    }),
+  ],
+};
+
+export const ThreeItemsAdminUser = Template.bind({});
+
+ThreeItemsAdminUser.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.adminUser);
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither);
+    }),
+    http.get("/api/UCSBOrganization/all", () => {
+      return HttpResponse.json(ucsbOrganizationFixtures.threeOrganizations);
+    }),
+    http.delete("/api/UCSBOrganization", () => {
+      return HttpResponse.json({}, { status: 200 });
+    }),
+  ],
+};

--- a/frontend/src/tests/components/UCSBOrganization/UCSBOrganizationTable.test.jsx
+++ b/frontend/src/tests/components/UCSBOrganization/UCSBOrganizationTable.test.jsx
@@ -162,7 +162,7 @@ describe("UCSBOrganizationTable tests", () => {
 
     await waitFor(() =>
       expect(mockedNavigate).toHaveBeenCalledWith(
-        "/ucsborganization/edit/DSClub",
+        "/ucsborganizations/edit/DSClub",
       ),
     );
   });

--- a/frontend/src/tests/pages/UCSBOrganization/UCSBOrganizationEditPage.test.jsx
+++ b/frontend/src/tests/pages/UCSBOrganization/UCSBOrganizationEditPage.test.jsx
@@ -1,47 +1,224 @@
-import { render, screen } from "@testing-library/react";
-import UCSBOrganizationEditPage from "main/pages/UCSBOrganization/UCSBOrganizationEditPage";
+import { fireEvent, render, waitFor, screen } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter } from "react-router";
+import UCSBOrganizationEditPage from "main/pages/UCSBOrganization/UCSBOrganizationEditPage";
 
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
-import { expect } from "vitest";
+
+import mockConsole from "tests/testutils/mockConsole";
+import { beforeEach, afterEach } from "vitest";
+
+const mockToast = vi.fn();
+vi.mock("react-toastify", async (importOriginal) => {
+  const originalModule = await importOriginal();
+  return {
+    ...originalModule,
+    toast: vi.fn((x) => mockToast(x)),
+  };
+});
+
+const mockNavigate = vi.fn();
+vi.mock("react-router", async (importOriginal) => {
+  const originalModule = await importOriginal();
+  return {
+    ...originalModule,
+    useParams: vi.fn(() => ({
+      orgCode: "DSClub",
+    })),
+    Navigate: vi.fn((x) => {
+      mockNavigate(x);
+      return null;
+    }),
+  };
+});
+
+let axiosMock;
 
 describe("UCSBOrganizationEditPage tests", () => {
-  const axiosMock = new AxiosMockAdapter(axios);
+  describe("when the backend doesn't return data", () => {
+    beforeEach(() => {
+      axiosMock = new AxiosMockAdapter(axios);
+      axiosMock
+        .onGet("/api/currentUser")
+        .reply(200, apiCurrentUserFixtures.userOnly);
+      axiosMock
+        .onGet("/api/systemInfo")
+        .reply(200, systemInfoFixtures.showingNeither);
+      axiosMock
+        .onGet("/api/UCSBOrganization", { params: { code: "DSClub" } })
+        .timeout();
+    });
 
-  const setupUserOnly = () => {
-    axiosMock.reset();
-    axiosMock.resetHistory();
-    axiosMock
-      .onGet("/api/currentUser")
-      .reply(200, apiCurrentUserFixtures.userOnly);
-    axiosMock
-      .onGet("/api/systemInfo")
-      .reply(200, systemInfoFixtures.showingNeither);
-  };
+    afterEach(() => {
+      mockToast.mockClear();
+      mockNavigate.mockClear();
+      axiosMock.restore();
+      axiosMock.resetHistory();
+    });
 
-  const queryClient = new QueryClient();
-  test("Renders expected content", async () => {
-    // arrange
+    const queryClient = new QueryClient();
 
-    setupUserOnly();
+    test("renders header but form is not present", async () => {
+      const restoreConsole = mockConsole();
 
-    // act
-    render(
-      <QueryClientProvider client={queryClient}>
-        <MemoryRouter>
-          <UCSBOrganizationEditPage />
-        </MemoryRouter>
-      </QueryClientProvider>,
-    );
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <UCSBOrganizationEditPage />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
 
-    // assert
-    await screen.findByText("Edit page not yet implemented");
-    expect(
-      screen.getByText("Edit page not yet implemented"),
-    ).toBeInTheDocument();
+      await screen.findByText(/Welcome/);
+      await screen.findByText("Edit UCSBOrganization");
+      expect(
+        screen.queryByTestId("UCSBOrganizationForm-orgCode"),
+      ).not.toBeInTheDocument();
+
+      restoreConsole();
+    });
+  });
+
+  describe("tests where backend is working normally", () => {
+    beforeEach(() => {
+      axiosMock = new AxiosMockAdapter(axios);
+      axiosMock.reset();
+      axiosMock.resetHistory();
+      axiosMock
+        .onGet("/api/currentUser")
+        .reply(200, apiCurrentUserFixtures.userOnly);
+      axiosMock
+        .onGet("/api/systemInfo")
+        .reply(200, systemInfoFixtures.showingNeither);
+      axiosMock
+        .onGet("/api/UCSBOrganization", { params: { code: "DSClub" } })
+        .reply(200, {
+          orgCode: "DSClub",
+          orgTranslationShort: "DSC",
+          orgTranslation: "Data Science Club",
+          inactive: false,
+        });
+      axiosMock.onPut("/api/UCSBOrganization").reply(200, {
+        orgCode: "DSClub",
+        orgTranslationShort: "DSC Updated",
+        orgTranslation: "Data Science Club Updated",
+        inactive: true,
+      });
+    });
+
+    afterEach(() => {
+      mockToast.mockClear();
+      mockNavigate.mockClear();
+      axiosMock.restore();
+      axiosMock.resetHistory();
+    });
+
+    const queryClient = new QueryClient();
+
+    test("renders without crashing", async () => {
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <UCSBOrganizationEditPage />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+
+      await screen.findByText(/Welcome/);
+      await screen.findByTestId("UCSBOrganizationForm-orgCode");
+
+      expect(
+        screen.getByTestId("UCSBOrganizationForm-orgCode"),
+      ).toBeInTheDocument();
+    });
+
+    test("Is populated with the data provided", async () => {
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <UCSBOrganizationEditPage />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+
+      await screen.findByTestId("UCSBOrganizationForm-orgCode");
+
+      const orgCodeField = screen.getByTestId("UCSBOrganizationForm-orgCode");
+      const orgTranslationShortField = screen.getByTestId(
+        "UCSBOrganizationForm-orgTranslationShort",
+      );
+      const orgTranslationField = screen.getByTestId(
+        "UCSBOrganizationForm-orgTranslation",
+      );
+      const inactiveField = screen.getByTestId("UCSBOrganizationForm-inactive");
+      const submitButton = screen.getByTestId("UCSBOrganizationForm-submit");
+
+      expect(orgCodeField).toHaveValue("DSClub");
+      expect(orgCodeField).toBeDisabled();
+      expect(orgTranslationShortField).toHaveValue("DSC");
+      expect(orgTranslationField).toHaveValue("Data Science Club");
+      expect(inactiveField).toHaveValue("false");
+      expect(submitButton).toBeInTheDocument();
+    });
+
+    test("Changes when you click Update", async () => {
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <UCSBOrganizationEditPage />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+
+      await screen.findByTestId("UCSBOrganizationForm-orgCode");
+
+      const orgCodeField = screen.getByTestId("UCSBOrganizationForm-orgCode");
+      const orgTranslationShortField = screen.getByTestId(
+        "UCSBOrganizationForm-orgTranslationShort",
+      );
+      const orgTranslationField = screen.getByTestId(
+        "UCSBOrganizationForm-orgTranslation",
+      );
+      const inactiveField = screen.getByTestId("UCSBOrganizationForm-inactive");
+      const submitButton = screen.getByTestId("UCSBOrganizationForm-submit");
+
+      expect(orgCodeField).toHaveValue("DSClub");
+      expect(orgTranslationShortField).toHaveValue("DSC");
+      expect(orgTranslationField).toHaveValue("Data Science Club");
+      expect(inactiveField).toHaveValue("false");
+      expect(submitButton).toBeInTheDocument();
+
+      fireEvent.change(orgTranslationShortField, {
+        target: { value: "DSC Updated" },
+      });
+      fireEvent.change(orgTranslationField, {
+        target: { value: "Data Science Club Updated" },
+      });
+      fireEvent.change(inactiveField, {
+        target: { value: "true" },
+      });
+
+      fireEvent.click(submitButton);
+
+      await waitFor(() => expect(mockToast).toBeCalled());
+
+      expect(mockToast).toBeCalledWith(
+        "UCSBOrganization Updated - orgCode: DSClub orgTranslationShort: DSC Updated orgTranslation: Data Science Club Updated inactive: true",
+      );
+      expect(mockNavigate).toBeCalledWith({ to: "/ucsborganizations" });
+
+      expect(axiosMock.history.put.length).toBe(1);
+      expect(axiosMock.history.put[0].params).toEqual({ code: "DSClub" });
+      expect(axiosMock.history.put[0].data).toBe(
+        JSON.stringify({
+          orgTranslationShort: "DSC Updated",
+          orgTranslation: "Data Science Club Updated",
+          inactive: "true",
+        }),
+      );
+    });
   });
 });

--- a/frontend/src/tests/pages/UCSBOrganization/UCSBOrganizationEditPage.test.jsx
+++ b/frontend/src/tests/pages/UCSBOrganization/UCSBOrganizationEditPage.test.jsx
@@ -48,7 +48,7 @@ describe("UCSBOrganizationEditPage tests", () => {
         .onGet("/api/systemInfo")
         .reply(200, systemInfoFixtures.showingNeither);
       axiosMock
-        .onGet("/api/UCSBOrganization", { params: { code: "DSClub" } })
+        .onGet("/api/UCSBOrganization", { params: { orgCode: "DSClub" } })
         .timeout();
     });
 
@@ -94,7 +94,7 @@ describe("UCSBOrganizationEditPage tests", () => {
         .onGet("/api/systemInfo")
         .reply(200, systemInfoFixtures.showingNeither);
       axiosMock
-        .onGet("/api/UCSBOrganization", { params: { code: "DSClub" } })
+        .onGet("/api/UCSBOrganization", { params: { orgCode: "DSClub" } })
         .reply(200, {
           orgCode: "DSClub",
           orgTranslationShort: "DSC",
@@ -211,7 +211,7 @@ describe("UCSBOrganizationEditPage tests", () => {
       expect(mockNavigate).toBeCalledWith({ to: "/ucsborganizations" });
 
       expect(axiosMock.history.put.length).toBe(1);
-      expect(axiosMock.history.put[0].params).toEqual({ code: "DSClub" });
+      expect(axiosMock.history.put[0].params).toEqual({ orgCode: "DSClub" });
       expect(axiosMock.history.put[0].data).toBe(
         JSON.stringify({
           orgTranslationShort: "DSC Updated",

--- a/frontend/src/tests/pages/UCSBOrganization/UCSBOrganizationIndexPage.test.jsx
+++ b/frontend/src/tests/pages/UCSBOrganization/UCSBOrganizationIndexPage.test.jsx
@@ -1,15 +1,28 @@
-import { render, screen } from "@testing-library/react";
-import UCSBOrganizationIndexPage from "main/pages/UCSBOrganization/UCSBOrganizationIndexPage";
+import { fireEvent, render, waitFor, screen } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter } from "react-router";
+import UCSBOrganizationIndexPage from "main/pages/UCSBOrganization/UCSBOrganizationIndexPage";
 
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { ucsbOrganizationFixtures } from "fixtures/ucsbOrganizationFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
+import mockConsole from "tests/testutils/mockConsole";
+
+const mockToast = vi.fn();
+vi.mock("react-toastify", async (importOriginal) => {
+  const originalModule = await importOriginal();
+  return {
+    ...originalModule,
+    toast: vi.fn((x) => mockToast(x)),
+  };
+});
 
 describe("UCSBOrganizationIndexPage tests", () => {
   const axiosMock = new AxiosMockAdapter(axios);
+
+  const testId = "UCSBOrganizationTable";
 
   const setupUserOnly = () => {
     axiosMock.reset();
@@ -22,13 +35,23 @@ describe("UCSBOrganizationIndexPage tests", () => {
       .reply(200, systemInfoFixtures.showingNeither);
   };
 
-  const queryClient = new QueryClient();
-  test("Renders expected content", async () => {
-    // arrange
+  const setupAdminUser = () => {
+    axiosMock.reset();
+    axiosMock.resetHistory();
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.adminUser);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+  };
 
-    setupUserOnly();
+  test("Renders with Create Button for admin user", async () => {
+    setupAdminUser();
 
-    // act
+    const queryClient = new QueryClient();
+
+    axiosMock.onGet("/api/UCSBOrganization/all").reply(200, []);
 
     render(
       <QueryClientProvider client={queryClient}>
@@ -38,13 +61,124 @@ describe("UCSBOrganizationIndexPage tests", () => {
       </QueryClientProvider>,
     );
 
-    await screen.findByText("Index page not yet implemented");
+    await waitFor(() => {
+      expect(screen.getByText(/Create UCSBOrganization/)).toBeInTheDocument();
+    });
 
-    // assert
+    const button = screen.getByText(/Create UCSBOrganization/);
+    expect(button).toHaveAttribute("href", "/ucsborganizations/create");
+    expect(button).toHaveAttribute("style", "float: right;");
+  });
+
+  test("renders three organizations correctly for regular user", async () => {
+    setupUserOnly();
+
+    const queryClient = new QueryClient();
+
+    axiosMock
+      .onGet("/api/UCSBOrganization/all")
+      .reply(200, ucsbOrganizationFixtures.threeOrganizations);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <UCSBOrganizationIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(`${testId}-cell-row-0-col-orgCode`),
+      ).toHaveTextContent("DSClub");
+    });
+
     expect(
-      screen.getByText("Index page not yet implemented"),
-    ).toBeInTheDocument();
-    expect(screen.getByText("Create")).toBeInTheDocument();
-    expect(screen.getByText("Edit")).toBeInTheDocument();
+      screen.getByTestId(`${testId}-cell-row-1-col-orgCode`),
+    ).toHaveTextContent("ACM");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-2-col-orgCode`),
+    ).toHaveTextContent("Chess");
+
+    expect(
+      screen.queryByText(/Create UCSBOrganization/),
+    ).not.toBeInTheDocument();
+  });
+
+  test("renders empty table when backend unavailable, user only", async () => {
+    setupUserOnly();
+
+    const queryClient = new QueryClient();
+
+    axiosMock.onGet("/api/UCSBOrganization/all").timeout();
+
+    const restoreConsole = mockConsole();
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <UCSBOrganizationIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(axiosMock.history.get.length).toBeGreaterThanOrEqual(1);
+    });
+
+    const errorMessage = console.error.mock.calls[0][0];
+    expect(errorMessage).toMatch(
+      "Error communicating with backend via GET on /api/UCSBOrganization/all",
+    );
+
+    restoreConsole();
+
+    expect(
+      screen.queryByTestId(`${testId}-cell-row-0-col-orgCode`),
+    ).not.toBeInTheDocument();
+  });
+
+  test("what happens when you click delete, admin", async () => {
+    setupAdminUser();
+
+    const queryClient = new QueryClient();
+
+    axiosMock
+      .onGet("/api/UCSBOrganization/all")
+      .reply(200, ucsbOrganizationFixtures.threeOrganizations);
+    axiosMock
+      .onDelete("/api/UCSBOrganization")
+      .reply(200, "UCSBOrganization with id DSClub was deleted");
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <UCSBOrganizationIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(`${testId}-cell-row-0-col-orgCode`),
+      ).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-orgCode`),
+    ).toHaveTextContent("DSClub");
+
+    const deleteButton = screen.getByTestId(
+      `${testId}-cell-row-0-col-Delete-button`,
+    );
+    expect(deleteButton).toBeInTheDocument();
+
+    fireEvent.click(deleteButton);
+
+    await waitFor(() => {
+      expect(mockToast).toBeCalledWith(
+        "UCSBOrganization with id DSClub was deleted",
+      );
+    });
   });
 });


### PR DESCRIPTION
Closes #17
Closes #18

In this PR we add the UCSBOrganization index and edit page.

To test index:

1. Visit this dokku deployment: https://team02-a-fat-cat-dev.dokku-01.cs.ucsb.edu
2. Login
3. Visit the UCSBOrganizations index page.
4. Create and delete should work properly.

To test edit:

1. Visit the dokku deployment at https://team02-a-fat-cat-dev.dokku-01.cs.ucsb.edu
2. Login
3. Navigate to the UCSBOrganizations page. If there isn't a UCSBOrganization listed there, create one.
4. Click the edit button
5. Make changes to each of the fields and click Update
6. See that your changes took effect.

Screenshot:

<img width="1368" height="214" alt="image" src="https://github.com/user-attachments/assets/9ca76793-a1a6-4a80-99e5-0b2eeaee3723" />

<img width="1582" height="436" alt="image" src="https://github.com/user-attachments/assets/b5b7cd67-4cee-4f31-969b-6e6f0e906bdf" />

Storybook:

UCSBOrganization index page:https://69f413a1c2ee91ec24c6314d-qwvaejplnx.chromatic.com/?path=/story/pages-ucsborganization-ucsborganizationindexpage--empty

UCSBOrganization edit page:https://69f413a1c2ee91ec24c6314d-qwvaejplnx.chromatic.com/?path=/story/pages-ucsborganization-ucsborganizationeditpage--default