### PR TITLE
Sherwin - Implemented End-to-End tests for HelpRequest

### DIFF
--- a/src/test/java/edu/ucsb/cs156/example/integration/HelpRequestIT.java
+++ b/src/test/java/edu/ucsb/cs156/example/integration/HelpRequestIT.java
@@ -1,0 +1,107 @@
+package edu.ucsb.cs156.example.integration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.ucsb.cs156.example.entities.HelpRequest;
+import edu.ucsb.cs156.example.repositories.HelpRequestRepository;
+import edu.ucsb.cs156.example.repositories.UserRepository;
+import edu.ucsb.cs156.example.services.CurrentUserService;
+import edu.ucsb.cs156.example.services.GrantedAuthoritiesService;
+import edu.ucsb.cs156.example.testconfig.TestConfig;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureMockMvc
+@ActiveProfiles("integration")
+@Import(TestConfig.class)
+@DirtiesContext(classMode = ClassMode.BEFORE_EACH_TEST_METHOD)
+public class HelpRequestIT {
+  @Autowired public CurrentUserService currentUserService;
+
+  @Autowired public GrantedAuthoritiesService grantedAuthoritiesService;
+
+  @Autowired HelpRequestRepository helpRequestRepository;
+
+  @Autowired public MockMvc mockMvc;
+
+  @Autowired public ObjectMapper mapper;
+
+  @MockitoBean UserRepository userRepository;
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void test_that_logged_in_user_can_get_by_id_when_the_id_exists() throws Exception {
+    // arrange
+
+    HelpRequest helpRequest =
+        HelpRequest.builder()
+            .requesterEmail("test@test.com")
+            .teamId("testTeamId")
+            .tableOrBreakoutRoom("table01")
+            .requestTime(LocalDateTime.parse("2022-02-02T00:00"))
+            .explanation("testExplanation")
+            .solved(true)
+            .build();
+
+    helpRequestRepository.save(helpRequest);
+
+    // act
+    MvcResult response =
+        mockMvc.perform(get("/api/helprequests?id=1")).andExpect(status().isOk()).andReturn();
+
+    // assert
+    String expectedJson = mapper.writeValueAsString(helpRequest);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, responseString);
+  }
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void an_admin_user_can_post_a_new_help_request() throws Exception {
+    // arrange
+
+    HelpRequest helpRequest1 =
+        HelpRequest.builder()
+            .id(1L)
+            .requesterEmail("test@test.com")
+            .teamId("testTeamId")
+            .tableOrBreakoutRoom("table01")
+            .requestTime(LocalDateTime.parse("2022-02-02T00:00"))
+            .explanation("testExplanation")
+            .solved(true)
+            .build();
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(
+                post("/api/helprequests/post?requesterEmail=test@test.com&teamId=testTeamId&tableOrBreakoutRoom=table01&requestTime=2022-02-02T00:00&explanation=testExplanation&solved=true")
+                    .with(csrf()))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    // assert
+    String expectedJson = mapper.writeValueAsString(helpRequest1);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, responseString);
+  }
+}

--- a/src/test/java/edu/ucsb/cs156/example/web/HelpRequestWebIT.java
+++ b/src/test/java/edu/ucsb/cs156/example/web/HelpRequestWebIT.java
@@ -1,0 +1,66 @@
+package edu.ucsb.cs156.example.web;
+
+import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
+
+import edu.ucsb.cs156.example.WebTestCase;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
+@ActiveProfiles("integration")
+@DirtiesContext(classMode = ClassMode.BEFORE_EACH_TEST_METHOD)
+public class HelpRequestWebIT extends WebTestCase {
+  @Test
+  public void admin_user_can_create_edit_delete_help_request() throws Exception {
+    setupUser(true);
+
+    page.getByText("HelpRequests").click();
+
+    page.getByText("Create HelpRequest").click();
+    assertThat(page.getByText("Create New HelpRequest")).isVisible();
+
+    page.getByTestId("HelpRequestForm-requesterEmail").fill("test@test.com");
+    page.getByTestId("HelpRequestForm-teamId").fill("team01");
+    page.getByTestId("HelpRequestForm-tableOrBreakoutRoom").fill("table01");
+    page.getByTestId("HelpRequestForm-requestTime").fill("2022-02-02T00:00");
+    page.getByTestId("HelpRequestForm-explanation").fill("Test Explanation");
+    page.getByTestId("HelpRequestForm-solved").click();
+
+    page.getByTestId("HelpRequestForm-submit").click();
+
+    assertThat(page.getByTestId("HelpRequestTable-cell-row-0-col-explanation"))
+        .hasText("Test Explanation");
+
+    page.getByTestId("HelpRequestTable-cell-row-0-col-Edit-button").click();
+    assertThat(page.getByText("Edit HelpRequest")).isVisible();
+    page.getByTestId("HelpRequestForm-explanation").fill("Updated explanation");
+    page.getByTestId("HelpRequestForm-submit").click();
+
+    assertThat(page.getByTestId("HelpRequestTable-cell-row-0-col-explanation"))
+        .hasText("Updated explanation");
+
+    page.getByTestId("HelpRequestTable-cell-row-0-col-Delete-button").click();
+
+    assertThat(page.getByTestId("HelpRequestTable-cell-row-0-col-requesterEmail"))
+        .not()
+        .isVisible();
+  }
+
+  @Test
+  public void regular_user_cannot_create_help_request() throws Exception {
+    setupUser(false);
+
+    page.getByText("HelpRequests").click();
+
+    assertThat(page.getByText("Create HelpRequest")).not().isVisible();
+    assertThat(page.getByTestId("HelpRequestTable-cell-row-0-col-requesterEmail"))
+        .not()
+        .isVisible();
+  }
+}


### PR DESCRIPTION
This PR implements End-to-End tests for `HelpRequest` that verify:
- Admin can create, edit, and delete a `HelpRequest`
- Regular user cannot create `HelpRequest`

`INTEGRATION=true mvn test-compile failsafe:integration-test -Dit.test=HelpRequestWebIT`
<img width="905" height="197" alt="image" src="https://github.com/user-attachments/assets/6d808234-8038-4fff-9bb8-d6ad3e8d5354" />

Closes: #100 