### PR TITLE
Whisper - e2e test for MenuItem

### DIFF
--- a/frontend/src/main/components/UCSBDiningCommonMenuItems/UCSBDiningCommonMenuItemsTable.jsx
+++ b/frontend/src/main/components/UCSBDiningCommonMenuItems/UCSBDiningCommonMenuItemsTable.jsx
@@ -44,7 +44,7 @@ export default function UCSBDiningCommonMenuItemsTable({
     },
     {
       header: "Dining Commons Menu Item",
-      accessorKey: "diningCommonsMenuItem",
+      accessorKey: "name",
     },
     {
       header: "Station",

--- a/frontend/src/tests/components/UCSBDiningCommonMenuItems/UCSBDiningCommonMenuItemsTable.test.jsx
+++ b/frontend/src/tests/components/UCSBDiningCommonMenuItems/UCSBDiningCommonMenuItemsTable.test.jsx
@@ -44,7 +44,7 @@ describe("UserTable tests", () => {
     const expectedFields = [
       "id",
       "diningCommonsCode",
-      "diningCommonsMenuItem",
+      "name",
       "station",
     ];
     const testId = "UCSBDiningCommonMenuItemsTable";
@@ -102,7 +102,7 @@ describe("UserTable tests", () => {
     const expectedFields = [
       "id",
       "diningCommonsCode",
-      "diningCommonsMenuItem",
+      "name",
       "station",
     ];
     const testId = "UCSBDiningCommonMenuItemsTable";

--- a/frontend/src/tests/components/UCSBDiningCommonMenuItems/UCSBDiningCommonMenuItemsTable.test.jsx
+++ b/frontend/src/tests/components/UCSBDiningCommonMenuItems/UCSBDiningCommonMenuItemsTable.test.jsx
@@ -41,12 +41,7 @@ describe("UserTable tests", () => {
       "Dining Commons Menu Item",
       "Station",
     ];
-    const expectedFields = [
-      "id",
-      "diningCommonsCode",
-      "name",
-      "station",
-    ];
+    const expectedFields = ["id", "diningCommonsCode", "name", "station"];
     const testId = "UCSBDiningCommonMenuItemsTable";
 
     expectedHeaders.forEach((headerText) => {
@@ -99,12 +94,7 @@ describe("UserTable tests", () => {
       "Dining Commons Menu Item",
       "Station",
     ];
-    const expectedFields = [
-      "id",
-      "diningCommonsCode",
-      "name",
-      "station",
-    ];
+    const expectedFields = ["id", "diningCommonsCode", "name", "station"];
     const testId = "UCSBDiningCommonMenuItemsTable";
 
     expectedHeaders.forEach((headerText) => {

--- a/src/test/java/edu/ucsb/cs156/example/web/UCSBDiningCommonMenuItemWebIT.java
+++ b/src/test/java/edu/ucsb/cs156/example/web/UCSBDiningCommonMenuItemWebIT.java
@@ -29,12 +29,22 @@ public class UCSBDiningCommonMenuItemWebIT extends WebTestCase {
     page.getByTestId("UCSBDiningCommonMenuItemForm-station").fill("station1");
     page.getByTestId("UCSBDiningCommonMenuItemForm-submit").click();
 
-    assertThat(page.getByTestId("UCSBDiningCommonMenuItemTable-cell-row-0-col-name"))
+    assertThat(page.getByTestId("UCSBDiningCommonMenuItemsTable-cell-row-0-col-name"))
         .hasText("name1");
 
-    page.getByTestId("UCSBDiningCommonMenuItemTable-cell-row-0-col-Delete-button").click();
+    page.getByTestId("UCSBDiningCommonMenuItemsTable-cell-row-0-col-Edit-button").click();
+    assertThat(page.getByText("Edit UCSBDiningCommonMenuItem")).isVisible();
+    page.getByTestId("UCSBDiningCommonMenuItemForm-name").fill("name2");
+    page.getByTestId("UCSBDiningCommonMenuItemForm-diningCommonsCode").fill("diningCommonsCode2");
+    page.getByTestId("UCSBDiningCommonMenuItemForm-station").fill("station2");
+    page.getByTestId("UCSBDiningCommonMenuItemForm-submit").click();
 
-    assertThat(page.getByTestId("UCSBDiningCommonMenuItemTable-cell-row-0-col-name"))
+    assertThat(page.getByTestId("UCSBDiningCommonMenuItemsTable-cell-row-0-col-name"))
+        .hasText("name2");
+
+    page.getByTestId("UCSBDiningCommonMenuItemsTable-cell-row-0-col-Delete-button").click();
+
+    assertThat(page.getByTestId("UCSBDiningCommonMenuItemsTable-cell-row-0-col-name"))
         .not()
         .isVisible();
   }
@@ -46,7 +56,7 @@ public class UCSBDiningCommonMenuItemWebIT extends WebTestCase {
     page.getByText("UCSBDiningCommonMenuItems").click();
 
     assertThat(page.getByText("Create UCSBDiningCommonMenuItem")).not().isVisible();
-    assertThat(page.getByTestId("UCSBDiningCommonMenuItemTable-cell-row-0-col-name"))
+    assertThat(page.getByTestId("UCSBDiningCommonMenuItemsTable-cell-row-0-col-name"))
         .not()
         .isVisible();
   }

--- a/src/test/java/edu/ucsb/cs156/example/web/UCSBDiningCommonMenuItemWebIT.java
+++ b/src/test/java/edu/ucsb/cs156/example/web/UCSBDiningCommonMenuItemWebIT.java
@@ -1,0 +1,53 @@
+package edu.ucsb.cs156.example.web;
+
+import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
+
+import edu.ucsb.cs156.example.WebTestCase;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
+@ActiveProfiles("integration")
+@DirtiesContext(classMode = ClassMode.BEFORE_EACH_TEST_METHOD)
+public class UCSBDiningCommonMenuItemWebIT extends WebTestCase {
+  @Test
+  public void admin_user_can_create_edit_delete_ucsbdiningcommonmenuitem() throws Exception {
+    setupUser(true);
+
+    page.getByText("UCSBDiningCommonMenuItems").click();
+
+    page.getByText("Create UCSBDiningCommonMenuItem").click();
+    assertThat(page.getByText("Create New UCSBDiningCommonMenuItem")).isVisible();
+    page.getByTestId("UCSBDiningCommonMenuItemForm-name").fill("name1");
+    page.getByTestId("UCSBDiningCommonMenuItemForm-diningCommonsCode").fill("diningCommonsCode1");
+    page.getByTestId("UCSBDiningCommonMenuItemForm-station").fill("station1");
+    page.getByTestId("UCSBDiningCommonMenuItemForm-submit").click();
+
+    assertThat(page.getByTestId("UCSBDiningCommonMenuItemTable-cell-row-0-col-name"))
+        .hasText("name1");
+
+    page.getByTestId("UCSBDiningCommonMenuItemTable-cell-row-0-col-Delete-button").click();
+
+    assertThat(page.getByTestId("UCSBDiningCommonMenuItemTable-cell-row-0-col-name"))
+        .not()
+        .isVisible();
+  }
+
+  @Test
+  public void regular_user_cannot_create_ucsbdiningcommonmenuitem() throws Exception {
+    setupUser(false);
+
+    page.getByText("UCSBDiningCommonMenuItems").click();
+
+    assertThat(page.getByText("Create UCSBDiningCommonMenuItem")).not().isVisible();
+    assertThat(page.getByTestId("UCSBDiningCommonMenuItemTable-cell-row-0-col-name"))
+        .not()
+        .isVisible();
+  }
+}


### PR DESCRIPTION
Closes #80  

E2E test file created with two tests:
- admin_user_can_create_edit_delete_ucsbdiningcommonmenuitem
- regular_user_cannot_create_ucsbdiningcommonmenuitem

Both are working and passing correctly.

<img width="757" height="263" alt="image" src="https://github.com/user-attachments/assets/7456cdab-37af-4192-af5d-1a24f542fde5" />
